### PR TITLE
Feature/#24 [FE] 공통 API 및 Types 작성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,7 +106,6 @@ dist
 .parcel-cache/
 
 .vscode/runtime*.js
-lib
 
 # Folder view configuration files
 .DS_Store

--- a/client/.babelrc
+++ b/client/.babelrc
@@ -8,6 +8,7 @@
     "@babel/typescript"
   ],
   "plugins": [
+    "@babel/plugin-transform-runtime",
     [
       "babel-plugin-root-import",
       {

--- a/client/.env.dev
+++ b/client/.env.dev
@@ -1,0 +1,2 @@
+NODE_ENV=development
+API_URL=http://localhost:5000

--- a/client/package.json
+++ b/client/package.json
@@ -7,15 +7,16 @@
   "author": "gomjellie <gomjellie@gmail.com>",
   "license": "MIT",
   "scripts": {
-    "start": "cross-env NODE_ENV=development webpack serve",
+    "start": "env-cmd -f .env.dev webpack serve",
     "prebuild": "rimraf dist",
-    "build": "cross-env NODE_ENV=production webpack --progress",
+    "build": "env-cmd webpack --progress",
     "lint": "npx eslint --ext .tsx --ext .ts src",
     "test": "jest",
     "test:watch": "jest --watchAll",
     "test:coverage": "jest --coverage"
   },
   "dependencies": {
+    "@babel/runtime": "^7.15.3",
     "axios": "^0.21.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
@@ -24,6 +25,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.15.0",
+    "@babel/plugin-transform-runtime": "^7.15.0",
     "@babel/preset-env": "^7.15.0",
     "@babel/preset-react": "^7.14.5",
     "@babel/preset-typescript": "^7.15.0",
@@ -37,8 +39,8 @@
     "babel-loader": "^8.2.2",
     "babel-plugin-root-import": "^6.6.0",
     "babel-plugin-styled-components": "^1.13.2",
-    "cross-env": "^7.0.3",
     "css-loader": "^6.2.0",
+    "env-cmd": "^10.1.0",
     "eslint": "^7.32.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-config-airbnb-base": "^14.2.1",

--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
     "test:coverage": "jest --coverage"
   },
   "dependencies": {
+    "axios": "^0.21.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-is": "^17.0.2",

--- a/client/package.json
+++ b/client/package.json
@@ -11,6 +11,7 @@
     "prebuild": "rimraf dist",
     "build": "env-cmd webpack --progress",
     "lint": "npx eslint --ext .tsx --ext .ts src",
+    "precommit": "eslint --fix --ext .tsx --ext .ts src && prettier --write src",
     "test": "jest",
     "test:watch": "jest --watchAll",
     "test:coverage": "jest --coverage"

--- a/client/src/lib/api/auth.ts
+++ b/client/src/lib/api/auth.ts
@@ -1,13 +1,7 @@
 import { AxiosResponse } from 'axios';
 import client from '~/lib/api/client';
-import {
-  ApiResponse,
-  AuthResponse,
-  AuthResponseBody,
-  ErrorResponse,
-  ErrorResponseBody,
-  LoginRequestBody,
-} from './types';
+import request from './request';
+import { AuthResponseBody, LoginRequestBody } from './types';
 
 export const authBaseUrl = '/api/auth';
 
@@ -22,39 +16,15 @@ const setAuthorizationHeader = (response: AxiosResponse<AuthResponseBody>) => {
   client.defaults.headers.common.Authorization = `Bearer ${access}`;
 };
 
-const authRequest = (
-  req: Promise<AxiosResponse<AuthResponseBody | ErrorResponseBody>>,
-): Promise<AuthResponse | ErrorResponse> =>
-  req.then((response) => {
-    const { status, data } = response;
-    if (response.status >= 400) {
-      const errorData = data as ErrorResponseBody;
-      const errorResponse: ErrorResponse = { statusCode: status, ...errorData };
-      return errorResponse;
-    }
-
-    const authResponse = response as AxiosResponse<AuthResponseBody>;
-    setAuthorizationHeader(authResponse);
-
-    const authData = data as AuthResponseBody;
-    const result: AuthResponse = { statusCode: status, ...authData };
-    return result;
-  });
-
-export const login = (
-  reqData: LoginRequestBody,
-): Promise<AuthResponse | ErrorResponse> =>
-  authRequest(
-    client.post<AuthResponseBody | ErrorResponseBody>(authUrl.login, reqData),
+export const login = (reqData: LoginRequestBody) =>
+  request<AuthResponseBody, LoginRequestBody>(
+    'POST',
+    authUrl.login,
+    reqData,
+    null,
+    setAuthorizationHeader,
   );
 
-export const logout = (): Promise<ApiResponse | ErrorResponse> =>
-  client.get<undefined | ErrorResponseBody>(authUrl.logout).then((response) => {
-    const { status, data } = response;
-    return { statusCode: status, ...data };
-  });
+export const logout = () => request('GET', authUrl.logout);
 
-export const refresh = (): Promise<AuthResponse | ErrorResponse> =>
-  authRequest(
-    client.get<AuthResponseBody | ErrorResponseBody>(authUrl.refresh),
-  );
+export const refresh = () => request<AuthResponseBody>('GET', authUrl.refresh);

--- a/client/src/lib/api/auth.ts
+++ b/client/src/lib/api/auth.ts
@@ -1,0 +1,58 @@
+import { AxiosResponse } from 'axios';
+import client from '~/lib/api/client';
+import {
+  ApiResponse,
+  AuthResponse,
+  AuthResponseBody,
+  ErrorResponse,
+  ErrorResponseBody,
+} from './types';
+
+export const authBaseUrl = '/api/auth';
+
+export const authUrl = {
+  login: `${authBaseUrl}/login`,
+  logout: `${authBaseUrl}/logout`,
+  refresh: `${authBaseUrl}/refresh`,
+};
+
+const setAuthorizationHeader = (response: AxiosResponse<AuthResponseBody>) => {
+  const { access } = response.data;
+  client.defaults.headers.common.Authorization = `Bearer ${access}`;
+};
+
+export const login = ({
+  email,
+  password,
+}): Promise<AuthResponse | ErrorResponse> =>
+  client
+    .post<AuthResponseBody | ErrorResponseBody>(authUrl.login, {
+      email,
+      password,
+    })
+    .then((response) => {
+      if (response.status < 400) {
+        const authResponse = response as AxiosResponse<AuthResponseBody>;
+        setAuthorizationHeader(authResponse);
+      }
+      const { status, data } = response;
+      return { statusCode: status, ...data };
+    });
+
+export const logout = (): Promise<ApiResponse | ErrorResponse> =>
+  client.get<undefined | ErrorResponseBody>(authUrl.logout).then((response) => {
+    const { status, data } = response;
+    return { statusCode: status, ...data };
+  });
+
+export const refresh = (): Promise<AuthResponse | ErrorResponse> =>
+  client
+    .get<AuthResponseBody | ErrorResponseBody>(authUrl.refresh)
+    .then((response) => {
+      if (response.status < 400) {
+        const authResponse = response as AxiosResponse<AuthResponseBody>;
+        setAuthorizationHeader(authResponse);
+      }
+      const { status, data } = response;
+      return { statusCode: status, ...data };
+    });

--- a/client/src/lib/api/auth.ts
+++ b/client/src/lib/api/auth.ts
@@ -6,6 +6,7 @@ import {
   AuthResponseBody,
   ErrorResponse,
   ErrorResponseBody,
+  LoginRequestBody,
 } from './types';
 
 export const authBaseUrl = '/api/auth';
@@ -21,15 +22,11 @@ const setAuthorizationHeader = (response: AxiosResponse<AuthResponseBody>) => {
   client.defaults.headers.common.Authorization = `Bearer ${access}`;
 };
 
-export const login = ({
-  email,
-  password,
-}): Promise<AuthResponse | ErrorResponse> =>
+export const login = (
+  reqData: LoginRequestBody,
+): Promise<AuthResponse | ErrorResponse> =>
   client
-    .post<AuthResponseBody | ErrorResponseBody>(authUrl.login, {
-      email,
-      password,
-    })
+    .post<AuthResponseBody | ErrorResponseBody>(authUrl.login, reqData)
     .then((response) => {
       if (response.status < 400) {
         const authResponse = response as AxiosResponse<AuthResponseBody>;

--- a/client/src/lib/api/cart.ts
+++ b/client/src/lib/api/cart.ts
@@ -1,0 +1,11 @@
+import request from './request';
+import { CartGetResponseBody } from './types/cart';
+
+export const cartBaseUrl = '/api/cart';
+
+export const cartUrl = {
+  cart: cartBaseUrl,
+};
+
+export const getCartItems = () =>
+  request<CartGetResponseBody[]>('GET', cartUrl.cart);

--- a/client/src/lib/api/categories.ts
+++ b/client/src/lib/api/categories.ts
@@ -1,0 +1,11 @@
+import request from './request';
+import { CategiresGetResponseBody } from './types/categories';
+
+export const categoriesBaseUrl = '/api/categories';
+
+export const categoriesUrl = {
+  categories: categoriesBaseUrl,
+};
+
+export const getCategories = () =>
+  request<CategiresGetResponseBody[]>('GET', categoriesUrl.categories);

--- a/client/src/lib/api/client.ts
+++ b/client/src/lib/api/client.ts
@@ -2,6 +2,6 @@ import axios from 'axios';
 
 const client = axios.create();
 
-// client.defaults.baseURL = 'https://???';
+client.defaults.baseURL = process.env.API_URL ?? '/';
 
 export default client;

--- a/client/src/lib/api/client.ts
+++ b/client/src/lib/api/client.ts
@@ -1,0 +1,7 @@
+import axios from 'axios';
+
+const client = axios.create();
+
+// client.defaults.baseURL = 'https://???';
+
+export default client;

--- a/client/src/lib/api/likes.ts
+++ b/client/src/lib/api/likes.ts
@@ -1,0 +1,11 @@
+import request from './request';
+import { LikesGetResponseBody } from './types/likes';
+
+export const likeBaseUrl = '/api/likes';
+
+export const likesUrl = {
+  likes: likeBaseUrl,
+};
+
+export const getLikeItems = () =>
+  request<LikesGetResponseBody[]>('GET', likesUrl.likes);

--- a/client/src/lib/api/products.ts
+++ b/client/src/lib/api/products.ts
@@ -1,0 +1,66 @@
+import request from './request';
+import {
+  ProductsGetRequestQuery,
+  ProductsGetResponseBody,
+  ProductDetailGetResponseBody,
+  ProductReviewsGetResponseBody,
+  ProductViewPostResponseBody,
+  ProductCartPostResponseBody,
+  ProductLikePostResponseBody,
+  ProductReviewPostRequestBody,
+  ProductReviewPostResponseBody,
+} from './types';
+
+export const productsBaseUrl = '/api/products';
+
+export const productsUrl = {
+  products: productsBaseUrl,
+  productDetail: (id: number) => `${productsBaseUrl}/${id}`,
+  productReviews: (id: number) => `${productsBaseUrl}/${id}/reviews`,
+  productView: (id: number) => `${productsBaseUrl}/${id}/view`,
+  productCart: (id: number) => `${productsBaseUrl}/${id}/cart`,
+  productReview: (id: number) => `${productsBaseUrl}/${id}/review`,
+  productLike: (id: number) => `${productsBaseUrl}/${id}/like`,
+};
+
+export const getProducts = (query?: ProductsGetRequestQuery) =>
+  request<ProductsGetResponseBody[], null, ProductsGetRequestQuery>(
+    'GET',
+    productsUrl.products,
+    null,
+    query,
+  );
+
+export const getProductDetail = (id: number) =>
+  request<ProductDetailGetResponseBody>('GET', productsUrl.productDetail(id));
+
+export const getProductReviews = (id: number) =>
+  request<ProductReviewsGetResponseBody[]>(
+    'GET',
+    productsUrl.productReviews(id),
+  );
+
+export const postProductToView = (id: number) =>
+  request<ProductViewPostResponseBody>('POST', productsUrl.productView(id));
+
+export const postProductToCart = (id: number) =>
+  request<ProductCartPostResponseBody>('POST', productsUrl.productCart(id));
+
+export const postProductToLike = (id: number) =>
+  request<ProductLikePostResponseBody>('POST', productsUrl.productLike(id));
+
+export const postReviewToProduct = (
+  id: number,
+  reqData: ProductReviewPostRequestBody,
+) =>
+  request<ProductReviewPostResponseBody, ProductReviewPostRequestBody>(
+    'POST',
+    productsUrl.productReview(id),
+    reqData,
+  );
+
+export const deleteProductFromCart = (id: number) =>
+  request('DELETE', productsUrl.productCart(id));
+
+export const deleteProductFromLike = (id: number) =>
+  request('DELETE', productsUrl.productLike(id));

--- a/client/src/lib/api/request.ts
+++ b/client/src/lib/api/request.ts
@@ -1,0 +1,57 @@
+import { AxiosResponse } from 'axios';
+import client from './client';
+import { ApiResponse, ErrorResponse, ErrorResponseBody, Method } from './types';
+
+/**
+ * HTTP 요청하는 함수.
+ *
+ * 순서대로 requestBody, responseBody, params에 대한 타입을 제네릭으로 받습니다.
+ *
+ * @param method 요청 메서드
+ * @param url 요청 URL
+ * @param body 요청 Body
+ * @param successCallback 성공 시 호출되는 Callback
+ * @param failureCallback 실패 시 호출되는 Callback
+ * @returns 응답
+ */
+const request = async <RES = unknown, REQ = null, PARAMS = null>(
+  method: Method,
+  url: string,
+  body?: REQ,
+  params?: PARAMS,
+  successCallback?: (response: AxiosResponse<RES>) => void,
+  failureCallback?: (response: AxiosResponse<ErrorResponseBody>) => void,
+): Promise<(RES & ApiResponse) | ErrorResponse> => {
+  const response = (await client({
+    method,
+    url,
+    params,
+    ...(body && { data: body }),
+  })) as AxiosResponse<RES | ErrorResponseBody>;
+
+  const { status, data } = response;
+  if (response.status >= 400) {
+    const errorData = data as ErrorResponseBody;
+    const errorResponse: ErrorResponse = { statusCode: status, ...errorData };
+
+    if (failureCallback) {
+      const axiosErrorResponse = response as AxiosResponse<ErrorResponse>;
+      failureCallback(axiosErrorResponse);
+    }
+    return errorResponse;
+  }
+
+  if (successCallback) {
+    const axiosErrorResponse = response as AxiosResponse<RES>;
+    successCallback(axiosErrorResponse);
+  }
+
+  const responseData = data as RES;
+  const resultResponse = {
+    statusCode: status,
+    ...responseData,
+  };
+  return resultResponse;
+};
+
+export default request;

--- a/client/src/lib/api/request.ts
+++ b/client/src/lib/api/request.ts
@@ -21,7 +21,7 @@ const request = async <RES = unknown, REQ = null, PARAMS = null>(
   params?: PARAMS,
   successCallback?: (response: AxiosResponse<RES>) => void,
   failureCallback?: (response: AxiosResponse<ErrorResponseBody>) => void,
-): Promise<(RES & ApiResponse) | ErrorResponse> => {
+): Promise<ApiResponse<RES> | ErrorResponse> => {
   const response = (await client({
     method,
     url,
@@ -32,10 +32,13 @@ const request = async <RES = unknown, REQ = null, PARAMS = null>(
   const { status, data } = response;
   if (response.status >= 400) {
     const errorData = data as ErrorResponseBody;
-    const errorResponse: ErrorResponse = { statusCode: status, ...errorData };
+    const errorResponse: ErrorResponse = {
+      statusCode: status,
+      data: errorData,
+    };
 
     if (failureCallback) {
-      const axiosErrorResponse = response as AxiosResponse<ErrorResponse>;
+      const axiosErrorResponse = response as AxiosResponse<ErrorResponseBody>;
       failureCallback(axiosErrorResponse);
     }
     return errorResponse;
@@ -47,9 +50,10 @@ const request = async <RES = unknown, REQ = null, PARAMS = null>(
   }
 
   const responseData = data as RES;
+
   const resultResponse = {
     statusCode: status,
-    ...responseData,
+    data: responseData,
   };
   return resultResponse;
 };

--- a/client/src/lib/api/reviews.ts
+++ b/client/src/lib/api/reviews.ts
@@ -1,0 +1,28 @@
+import request from './request';
+import {
+  ReviewDetailGetResponseBody,
+  ReviewDetailPutRequsetBody,
+  ReviewDetailPutResponseBody,
+} from './types/reviews';
+
+export const reviewsBaseUrl = '/api/reviews';
+
+export const reviewsUrl = {
+  reviewDetail: (id: number) => `${reviewsBaseUrl}/${id}`,
+};
+
+export const getReviewDetail = (id: number) =>
+  request<ReviewDetailGetResponseBody>('GET', reviewsUrl.reviewDetail(id));
+
+export const putReviewDetail = (
+  id: number,
+  reqData: ReviewDetailPutRequsetBody,
+) =>
+  request<ReviewDetailPutResponseBody, ReviewDetailPutRequsetBody>(
+    'PUT',
+    reviewsUrl.reviewDetail(id),
+    reqData,
+  );
+
+export const deleteReviewDetail = (id: number) =>
+  request('DELETE', reviewsUrl.reviewDetail(id));

--- a/client/src/lib/api/shipping.ts
+++ b/client/src/lib/api/shipping.ts
@@ -1,0 +1,38 @@
+import request from './request';
+import {} from './types/cart';
+
+import {
+  ShippingsGetResponseBody,
+  ShippingsPostRequestBody,
+  ShippingsPostResponseBody,
+  ShippingPutRequsetBody,
+  ShippingPutResponseBody,
+} from './types';
+
+export const shippingBaseUrl = '/api/shippings';
+
+export const shippingsUrl = {
+  shippings: () => shippingBaseUrl,
+  shippingPost: () => shippingBaseUrl,
+  shippingDetail: (id: number) => `${shippingBaseUrl}/${id}`,
+};
+
+export const getShippings = () =>
+  request<ShippingsGetResponseBody[]>('GET', shippingsUrl.shippings());
+
+export const postShpping = (reqData: ShippingsPostRequestBody) =>
+  request<ShippingsPostResponseBody, ShippingsPostRequestBody>(
+    'POST',
+    shippingsUrl.shippingPost(),
+    reqData,
+  );
+
+export const putShipping = (id: number, reqData: ShippingPutRequsetBody) =>
+  request<ShippingPutResponseBody, ShippingPutRequsetBody>(
+    'PUT',
+    shippingsUrl.shippingDetail(id),
+    reqData,
+  );
+
+export const deleteShipping = (id: number) =>
+  request('DELETE', shippingsUrl.shippingDetail(id));

--- a/client/src/lib/api/types/api.ts
+++ b/client/src/lib/api/types/api.ts
@@ -1,0 +1,5 @@
+interface ApiResponse {
+  statusCode: number;
+}
+
+export default ApiResponse;

--- a/client/src/lib/api/types/api.ts
+++ b/client/src/lib/api/types/api.ts
@@ -1,5 +1,0 @@
-interface ApiResponse {
-  statusCode: number;
-}
-
-export default ApiResponse;

--- a/client/src/lib/api/types/auth.ts
+++ b/client/src/lib/api/types/auth.ts
@@ -1,5 +1,10 @@
 import ApiResponse from './api';
 
+export interface LoginRequestBody {
+  id: string;
+  password: string;
+}
+
 export interface AuthResponseBody {
   access: string;
 }

--- a/client/src/lib/api/types/auth.ts
+++ b/client/src/lib/api/types/auth.ts
@@ -9,4 +9,4 @@ export interface AuthResponseBody {
   access: string;
 }
 
-export interface AuthResponse extends ApiResponse, AuthResponseBody {}
+export type AuthResponse = ApiResponse<AuthResponseBody>;

--- a/client/src/lib/api/types/auth.ts
+++ b/client/src/lib/api/types/auth.ts
@@ -1,4 +1,4 @@
-import ApiResponse from './api';
+import { ApiResponse } from './common';
 
 export interface LoginRequestBody {
   id: string;

--- a/client/src/lib/api/types/auth.ts
+++ b/client/src/lib/api/types/auth.ts
@@ -1,0 +1,7 @@
+import ApiResponse from './api';
+
+export interface AuthResponseBody {
+  access: string;
+}
+
+export interface AuthResponse extends ApiResponse, AuthResponseBody {}

--- a/client/src/lib/api/types/cart.ts
+++ b/client/src/lib/api/types/cart.ts
@@ -1,0 +1,8 @@
+export interface CartGetResponseBody {
+  idx: number;
+  name: string;
+  thumbnail: string;
+  price: number;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/client/src/lib/api/types/categories.ts
+++ b/client/src/lib/api/types/categories.ts
@@ -1,0 +1,7 @@
+export interface CategiresGetResponseBody {
+  idx: number;
+  name: string;
+  image: string;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/client/src/lib/api/types/common.ts
+++ b/client/src/lib/api/types/common.ts
@@ -1,9 +1,16 @@
+export type Method = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
 export interface ApiResponse {
   statusCode: number;
 }
 
-export interface UpdateInfo {
+export interface UpdateDateInfo {
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface UpdateInfo extends UpdateDateInfo {
   idx: number;
-  createdAt: Date | string;
-  updatedAt: Date | string;
+  createdAt: string;
+  updatedAt: string;
 }

--- a/client/src/lib/api/types/common.ts
+++ b/client/src/lib/api/types/common.ts
@@ -1,0 +1,9 @@
+export interface ApiResponse {
+  statusCode: number;
+}
+
+export interface UpdateInfo {
+  idx: number;
+  createdAt: Date | string;
+  updatedAt: Date | string;
+}

--- a/client/src/lib/api/types/common.ts
+++ b/client/src/lib/api/types/common.ts
@@ -1,7 +1,8 @@
 export type Method = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 
-export interface ApiResponse {
+export interface ApiResponse<T> {
   statusCode: number;
+  data: T;
 }
 
 export interface UpdateDateInfo {

--- a/client/src/lib/api/types/error.ts
+++ b/client/src/lib/api/types/error.ts
@@ -1,0 +1,10 @@
+import ApiResponse from './api';
+
+export interface ErrorResponseBody {
+  success: boolean;
+  statusCode: number;
+  message: string;
+  stack?: string;
+}
+
+export interface ErrorResponse extends ApiResponse, ErrorResponseBody {}

--- a/client/src/lib/api/types/error.ts
+++ b/client/src/lib/api/types/error.ts
@@ -1,4 +1,4 @@
-import ApiResponse from './api';
+import { ApiResponse } from './common';
 
 export interface ErrorResponseBody {
   success: boolean;

--- a/client/src/lib/api/types/error.ts
+++ b/client/src/lib/api/types/error.ts
@@ -7,4 +7,4 @@ export interface ErrorResponseBody {
   stack?: string;
 }
 
-export interface ErrorResponse extends ApiResponse, ErrorResponseBody {}
+export type ErrorResponse = ApiResponse<ErrorResponseBody>;

--- a/client/src/lib/api/types/index.ts
+++ b/client/src/lib/api/types/index.ts
@@ -1,18 +1,3 @@
-export interface ApiResponse {
-  statusCode: number;
-}
-
-export interface ErrorResponseBody {
-  success: boolean;
-  statusCode: number;
-  message: string;
-  stack?: string;
-}
-
-export interface AuthResponseBody {
-  access: string;
-}
-
-export interface ErrorResponse extends ApiResponse, ErrorResponseBody {}
-
-export interface AuthResponse extends ApiResponse, AuthResponseBody {}
+export { default as ApiResponse } from './api';
+export * from './error';
+export * from './auth';

--- a/client/src/lib/api/types/index.ts
+++ b/client/src/lib/api/types/index.ts
@@ -1,3 +1,4 @@
 export { default as ApiResponse } from './api';
 export * from './error';
 export * from './auth';
+export * from './users';

--- a/client/src/lib/api/types/index.ts
+++ b/client/src/lib/api/types/index.ts
@@ -1,4 +1,4 @@
-export { default as ApiResponse } from './api';
+export * from './common';
 export * from './error';
 export * from './auth';
 export * from './users';

--- a/client/src/lib/api/types/index.ts
+++ b/client/src/lib/api/types/index.ts
@@ -2,3 +2,7 @@ export * from './common';
 export * from './error';
 export * from './auth';
 export * from './users';
+export * from './products';
+export * from './categories';
+export * from './cart';
+export * from './shippings';

--- a/client/src/lib/api/types/index.ts
+++ b/client/src/lib/api/types/index.ts
@@ -1,0 +1,18 @@
+export interface ApiResponse {
+  statusCode: number;
+}
+
+export interface ErrorResponseBody {
+  success: boolean;
+  statusCode: number;
+  message: string;
+  stack?: string;
+}
+
+export interface AuthResponseBody {
+  access: string;
+}
+
+export interface ErrorResponse extends ApiResponse, ErrorResponseBody {}
+
+export interface AuthResponse extends ApiResponse, AuthResponseBody {}

--- a/client/src/lib/api/types/likes.ts
+++ b/client/src/lib/api/types/likes.ts
@@ -1,0 +1,8 @@
+export interface LikesGetResponseBody {
+  idx: number;
+  name: string;
+  thumbnail: string;
+  price: number;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/client/src/lib/api/types/products.ts
+++ b/client/src/lib/api/types/products.ts
@@ -1,0 +1,76 @@
+export interface ProductsGetRequestQuery {
+  category?: number;
+  search?: string;
+  order?: string;
+  offset?: string;
+  limit?: string;
+}
+
+export interface ProductsGetResponseBody {
+  idx: number;
+  title: string;
+  thumbnail: string;
+  price: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ProductDetailGetResponseBody {
+  idx: number;
+  name: string;
+  price: number;
+  images: string[];
+  description: string;
+  shipSummary: string;
+  shipDetail: string;
+  policy: string;
+  viewCnt: number;
+  reviewCnt: number;
+  likeCnt: number;
+  isLike?: boolean;
+  isCart?: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ProductReviewsGetResponseBody {
+  idx: number;
+  title: string;
+  user: {
+    idx: number;
+    id: string;
+  };
+  rate: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ProductViewPostResponseBody {
+  idx: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ProductCartPostResponseBody {
+  idx: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ProductLikePostResponseBody {
+  idx: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ProductReviewPostRequestBody {
+  title: string;
+  content: string;
+  rate: number;
+}
+
+export interface ProductReviewPostResponseBody {
+  idx: number;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/client/src/lib/api/types/reviews.ts
+++ b/client/src/lib/api/types/reviews.ts
@@ -1,0 +1,25 @@
+export interface ReviewDetailGetResponseBody {
+  idx: number;
+  title: string;
+  content: string;
+  user: {
+    idx: number;
+    id: string;
+  };
+  rate: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface ReviewDetailPutResponseBody {
+  idx: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ReviewDetailPutRequsetBody {
+  idx: number;
+  title: string;
+  content: string;
+  rate: number;
+}

--- a/client/src/lib/api/types/shippings.ts
+++ b/client/src/lib/api/types/shippings.ts
@@ -1,0 +1,29 @@
+export interface ShippingsGetResponseBody {
+  idx: number;
+  name: string;
+  address: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface ShippingsPostRequestBody {
+  name: string;
+  address: string;
+}
+
+export interface ShippingsPostResponseBody {
+  idx: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ShippingPutRequsetBody {
+  name: string;
+  address: string;
+}
+
+export interface ShippingPutResponseBody {
+  idx: number;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/client/src/lib/api/types/users.ts
+++ b/client/src/lib/api/types/users.ts
@@ -1,16 +1,12 @@
-import ApiResponse from './api';
+import { ApiResponse, UpdateInfo } from './common';
 
 export interface UserInfo {
   email?: string;
   phone?: string;
   profile?: string;
 }
-export interface UserUpdateInfo {
-  idx: number;
-  createdAt: Date | string;
-  updatedAt: Date | string;
-}
-export interface User extends UserInfo, UserUpdateInfo {
+
+export interface User extends UserInfo, UpdateInfo {
   id: string;
   phone: string;
 }
@@ -30,18 +26,18 @@ export interface UsersGetResponseBody extends User {
   createdAt: string;
   updatedAt: string;
 }
-export interface UsersPostResponseBody extends UserUpdateInfo {
+export interface UsersPostResponseBody extends UpdateInfo {
   createdAt: string;
   updatedAt: string;
 }
-export interface UsersPutResponseBody extends UserUpdateInfo {
+export interface UsersPutResponseBody extends UpdateInfo {
   createdAt: string;
   updatedAt: string;
 }
 
 /// //////////////////////////////////////////////////////////
 
-export interface UserResponse extends ApiResponse, UserUpdateInfo {
+export interface UserResponse extends ApiResponse, UpdateInfo {
   createdAt: Date;
   updatedAt: Date;
 }

--- a/client/src/lib/api/types/users.ts
+++ b/client/src/lib/api/types/users.ts
@@ -1,52 +1,26 @@
-import { ApiResponse, UpdateInfo } from './common';
+import { UpdateInfo } from './common';
 
-export interface UserInfo {
+export interface UsersPostRequestBody {
+  id: string;
+  password: string;
+  type?: string;
+  email?: string;
+  phone: string;
+  profile?: string;
+}
+export type UsersPostResponseBody = UpdateInfo;
+
+export interface UsersGetResponseBody extends UpdateInfo {
+  id: string;
+  email: string;
+  phone: string;
+  profile: string;
+}
+
+export interface UsersPutRequestBody {
+  password?: string;
   email?: string;
   phone?: string;
   profile?: string;
 }
-
-export interface User extends UserInfo, UpdateInfo {
-  id: string;
-  phone: string;
-}
-
-/// //////////////////////////////////////////////////////////
-
-export interface UsersPostRequestBody extends UserInfo {
-  id: string;
-  password: string;
-  phone: string;
-  type?: string;
-}
-export interface UsersPutRequestBody extends UserInfo {
-  password?: string;
-}
-export interface UsersGetResponseBody extends User {
-  createdAt: string;
-  updatedAt: string;
-}
-export interface UsersPostResponseBody extends UpdateInfo {
-  createdAt: string;
-  updatedAt: string;
-}
-export interface UsersPutResponseBody extends UpdateInfo {
-  createdAt: string;
-  updatedAt: string;
-}
-
-/// //////////////////////////////////////////////////////////
-
-export interface UserResponse extends ApiResponse, UpdateInfo {
-  createdAt: Date;
-  updatedAt: Date;
-}
-export interface UsersGetResponse extends UserResponse, User {
-  id: string;
-  email: string;
-  profile: string;
-  createdAt: Date;
-  updatedAt: Date;
-}
-export type UsersPostResponse = UserResponse;
-export type UsersPutResponse = UserResponse;
+export type UsersPutResponseBody = UpdateInfo;

--- a/client/src/lib/api/types/users.ts
+++ b/client/src/lib/api/types/users.ts
@@ -1,0 +1,56 @@
+import ApiResponse from './api';
+
+export interface UserInfo {
+  email?: string;
+  phone?: string;
+  profile?: string;
+}
+export interface UserUpdateInfo {
+  idx: number;
+  createdAt: Date | string;
+  updatedAt: Date | string;
+}
+export interface User extends UserInfo, UserUpdateInfo {
+  id: string;
+  phone: string;
+}
+
+/// //////////////////////////////////////////////////////////
+
+export interface UsersPostRequestBody extends UserInfo {
+  id: string;
+  password: string;
+  phone: string;
+  type?: string;
+}
+export interface UsersPutRequestBody extends UserInfo {
+  password?: string;
+}
+export interface UsersGetResponseBody extends User {
+  createdAt: string;
+  updatedAt: string;
+}
+export interface UsersPostResponseBody extends UserUpdateInfo {
+  createdAt: string;
+  updatedAt: string;
+}
+export interface UsersPutResponseBody extends UserUpdateInfo {
+  createdAt: string;
+  updatedAt: string;
+}
+
+/// //////////////////////////////////////////////////////////
+
+export interface UserResponse extends ApiResponse, UserUpdateInfo {
+  createdAt: Date;
+  updatedAt: Date;
+}
+export interface UsersGetResponse extends UserResponse, User {
+  id: string;
+  email: string;
+  profile: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+export type UsersPostResponse = UserResponse;
+export type UsersPutResponse = UserResponse;

--- a/client/src/lib/api/users.ts
+++ b/client/src/lib/api/users.ts
@@ -12,7 +12,7 @@ import {
   UsersPutRequestBody,
   UsersPutResponse,
   UsersPutResponseBody,
-  UserUpdateInfo,
+  UpdateInfo,
 } from './types';
 
 export const usersBaseUrl = '/api/users';
@@ -22,7 +22,7 @@ export const usersUrl = {
   me: `${usersBaseUrl}/me`,
 };
 
-const userRequest = <T extends UserUpdateInfo>(
+const userRequest = <T extends UpdateInfo>(
   req: Promise<AxiosResponse<T | ErrorResponseBody>>,
 ): Promise<
   UsersGetResponse | UsersPostResponse | UsersPutResponse | ErrorResponse

--- a/client/src/lib/api/users.ts
+++ b/client/src/lib/api/users.ts
@@ -1,18 +1,10 @@
-import { AxiosResponse } from 'axios';
-import client from './client';
+import request from './request';
 import {
-  ApiResponse,
-  ErrorResponse,
-  ErrorResponseBody,
-  UsersGetResponse,
   UsersGetResponseBody,
   UsersPostRequestBody,
-  UsersPostResponse,
   UsersPostResponseBody,
   UsersPutRequestBody,
-  UsersPutResponse,
   UsersPutResponseBody,
-  UpdateInfo,
 } from './types';
 
 export const usersBaseUrl = '/api/users';
@@ -22,59 +14,20 @@ export const usersUrl = {
   me: `${usersBaseUrl}/me`,
 };
 
-const userRequest = <T extends UpdateInfo>(
-  req: Promise<AxiosResponse<T | ErrorResponseBody>>,
-): Promise<
-  UsersGetResponse | UsersPostResponse | UsersPutResponse | ErrorResponse
-> =>
-  req.then((response) => {
-    const { status, data } = response;
-    if (response.status >= 400) {
-      const errorData = data as ErrorResponseBody;
-      const errorResponse: ErrorResponse = { statusCode: status, ...errorData };
-      return errorResponse;
-    }
-    const userData = data as T;
-    const userResponse = {
-      statusCode: status,
-      ...userData,
-      createdAt: new Date(userData.createdAt),
-      updatedAt: new Date(userData.updatedAt),
-    };
+export const postUser = (reqData: UsersPostRequestBody) =>
+  request<UsersPostResponseBody, UsersPostRequestBody>(
+    'POST',
+    usersUrl.users,
+    reqData,
+  );
 
-    return userResponse;
-  });
+export const getMe = () => request<UsersGetResponseBody>('GET', usersUrl.me);
 
-export const createUser = (
-  reqData: UsersPostRequestBody,
-): Promise<UsersPostResponse | ErrorResponse> =>
-  userRequest<UsersPostResponseBody>(
-    client.post<UsersPostResponseBody | ErrorResponseBody>(
-      usersUrl.users,
-      reqData,
-    ),
-  ).then((result) => {
-    return result as UsersPostResponse | ErrorResponse;
-  });
+export const putMe = (reqData: UsersPutRequestBody) =>
+  request<UsersPutResponseBody, UsersPutRequestBody>(
+    'PUT',
+    usersUrl.me,
+    reqData,
+  );
 
-export const getMe = (): Promise<UsersGetResponse | ErrorResponse> =>
-  userRequest<UsersGetResponseBody>(
-    client.get<UsersGetResponseBody | ErrorResponseBody>(usersUrl.me),
-  ).then((result) => {
-    return result as UsersGetResponse | ErrorResponse;
-  });
-
-export const updateMe = (
-  reqData: UsersPutRequestBody,
-): Promise<UsersPutResponse | ErrorResponse> =>
-  userRequest<UsersPutResponseBody>(
-    client.put<UsersPutResponseBody | ErrorResponseBody>(usersUrl.me, reqData),
-  ).then((result) => {
-    return result as UsersPutResponse | ErrorResponse;
-  });
-
-export const deleteMe = (): Promise<ApiResponse | ErrorResponse> =>
-  client.delete<undefined | ErrorResponseBody>(usersUrl.me).then((response) => {
-    const { status, data } = response;
-    return { statusCode: status, ...data };
-  });
+export const deleteMe = () => request('DELETE', usersUrl.me);

--- a/client/src/lib/api/users.ts
+++ b/client/src/lib/api/users.ts
@@ -1,0 +1,80 @@
+import { AxiosResponse } from 'axios';
+import client from './client';
+import {
+  ApiResponse,
+  ErrorResponse,
+  ErrorResponseBody,
+  UsersGetResponse,
+  UsersGetResponseBody,
+  UsersPostRequestBody,
+  UsersPostResponse,
+  UsersPostResponseBody,
+  UsersPutRequestBody,
+  UsersPutResponse,
+  UsersPutResponseBody,
+  UserUpdateInfo,
+} from './types';
+
+export const usersBaseUrl = '/api/users';
+
+export const usersUrl = {
+  users: usersBaseUrl,
+  me: `${usersBaseUrl}/me`,
+};
+
+const userRequest = <T extends UserUpdateInfo>(
+  req: Promise<AxiosResponse<T | ErrorResponseBody>>,
+): Promise<
+  UsersGetResponse | UsersPostResponse | UsersPutResponse | ErrorResponse
+> =>
+  req.then((response) => {
+    const { status, data } = response;
+    if (response.status >= 400) {
+      const errorData = data as ErrorResponseBody;
+      const errorResponse: ErrorResponse = { statusCode: status, ...errorData };
+      return errorResponse;
+    }
+    const userData = data as T;
+    const userResponse = {
+      statusCode: status,
+      ...userData,
+      createdAt: new Date(userData.createdAt),
+      updatedAt: new Date(userData.updatedAt),
+    };
+
+    return userResponse;
+  });
+
+export const createUser = (
+  reqData: UsersPostRequestBody,
+): Promise<UsersPostResponse | ErrorResponse> =>
+  userRequest<UsersPostResponseBody>(
+    client.post<UsersPostResponseBody | ErrorResponseBody>(
+      usersUrl.users,
+      reqData,
+    ),
+  ).then((result) => {
+    return result as UsersPostResponse | ErrorResponse;
+  });
+
+export const getMe = (): Promise<UsersGetResponse | ErrorResponse> =>
+  userRequest<UsersGetResponseBody>(
+    client.get<UsersGetResponseBody | ErrorResponseBody>(usersUrl.me),
+  ).then((result) => {
+    return result as UsersGetResponse | ErrorResponse;
+  });
+
+export const updateMe = (
+  reqData: UsersPutRequestBody,
+): Promise<UsersPutResponse | ErrorResponse> =>
+  userRequest<UsersPutResponseBody>(
+    client.put<UsersPutResponseBody | ErrorResponseBody>(usersUrl.me, reqData),
+  ).then((result) => {
+    return result as UsersPutResponse | ErrorResponse;
+  });
+
+export const deleteMe = (): Promise<ApiResponse | ErrorResponse> =>
+  client.delete<undefined | ErrorResponseBody>(usersUrl.me).then((response) => {
+    const { status, data } = response;
+    return { statusCode: status, ...data };
+  });

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const webpack = require('webpack');
 
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
@@ -53,6 +54,9 @@ module.exports = {
     new HtmlWebpackPlugin({
       template: './src/index.html',
       filename: 'index.html',
+    }),
+    new webpack.DefinePlugin({
+      "process.env.API_URL": JSON.stringify(process.env.API_URL)
     }),
     new ForkTsCheckerWebpackPlugin({ typescript: true }),
   ],

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -56,7 +56,7 @@ module.exports = {
       filename: 'index.html',
     }),
     new webpack.DefinePlugin({
-      "process.env.API_URL": JSON.stringify(process.env.API_URL)
+      'process.env.API_URL': JSON.stringify(process.env.API_URL),
     }),
     new ForkTsCheckerWebpackPlugin({ typescript: true }),
   ],

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2023,6 +2023,13 @@ axe-core@^4.0.2:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.3.2.tgz#fcf8777b82c62cfc69c7e9f32c0d2226287680e7"
   integrity sha512-5LMaDRWm8ZFPAEdzTYmgjjEdj1YnQcpfrVajO/sn/LhbpGp0Y0H64c2hLZI1gRMxfA+w1S71Uc/nHaOXgcCvGg==
 
+axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+  dependencies:
+    follow-redirects "^1.10.0"
+
 axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
@@ -3727,7 +3734,7 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.2.tgz#64bfed5cb68fe3ca78b3eb214ad97b63bedce561"
   integrity sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==
 
-follow-redirects@^1.0.0:
+follow-redirects@^1.0.0, follow-redirects@^1.10.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.1.tgz#d9114ded0a1cfdd334e164e6662ad02bfd91ff43"
   integrity sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -761,6 +761,18 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
+"@babel/plugin-transform-runtime@^7.15.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.15.0.tgz#d3aa650d11678ca76ce294071fda53d7804183b3"
+  integrity sha512-sfHYkLGjhzWTq6xsuQ01oEsUYjkHRux9fW1iUA68dC7Qd8BS1Unq4aZ8itmQp95zUzIcyR2EbNMTzAicFj+guw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.14.5"
+    "@babel/helper-plugin-utils" "^7.14.5"
+    babel-plugin-polyfill-corejs2 "^0.2.2"
+    babel-plugin-polyfill-corejs3 "^0.2.2"
+    babel-plugin-polyfill-regenerator "^0.2.2"
+    semver "^6.3.0"
+
 "@babel/plugin-transform-shorthand-properties@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.14.5.tgz#97f13855f1409338d8cadcbaca670ad79e091a58"
@@ -947,7 +959,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.12.5", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.15.3", "@babel/runtime@^7.9.2":
   version "7.15.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.3.tgz#2e1c2880ca118e5b2f9988322bd8a7656a32502b"
   integrity sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==
@@ -2556,7 +2568,7 @@ commander@^2.20.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-commander@^4.1.1:
+commander@^4.0.0, commander@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
@@ -2674,13 +2686,6 @@ cosmiconfig@^6.0.0:
     path-type "^4.0.0"
     yaml "^1.7.2"
 
-cross-env@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
-  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
-  dependencies:
-    cross-spawn "^7.0.1"
-
 cross-spawn@^6.0.0:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -2692,7 +2697,7 @@ cross-spawn@^6.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -3107,6 +3112,14 @@ entities@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
+
+env-cmd@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/env-cmd/-/env-cmd-10.1.0.tgz#c7f5d3b550c9519f137fdac4dd8fb6866a8c8c4b"
+  integrity sha512-mMdWTT9XKN7yNth/6N6g2GuKuJTsKMDHlQFUDacb/heQRRWOTIZ42t1rMHnQu4jYxU1ajdTeJM+9eEETlqToMA==
+  dependencies:
+    commander "^4.0.0"
+    cross-spawn "^7.0.0"
 
 envinfo@^7.7.3:
   version "7.8.1"


### PR DESCRIPTION
## :bookmark_tabs: 제목

API 요청 함수들에 대해서 구현하고 각 요청에 대한 Request, Response 등에 대한 타입 선언을 해줬습니다.

## :paperclip: 관련 이슈

- closes #24 

## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [X] Warning Message가 발생하지 않았나요?
- [X] Coding Convention을 준수했나요?
- [ ] Test Code를 작성하였나요?
    - 서버쪽 API 쪽이 구현되지 않아서 생략했습니다.(무조건 실패하기 때문에...)

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] API 명세를 토대로한 API 요청 함수들 작성
- [x] 각 요청 함수들의 Request Body, Response Body, QueryString 등에 대해 타입 선언
- [x] 환경 변수 설정을 위해 cross-env 대신 별도의 파일(.env, .env.dev)로 분리할 수 있는 env-cmd 패키지 사용
- [X] webpack 설정에서 API_URL 환경 변수 설정 

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- webpack 설정을 통해 클라이언트 코드 상의 process.env.API_URL은 빌드될 때 해당 환경 변수의 값으로 치환됩니다.
- lib/api/types 밑으로 API Request Body / Response Body 에 대한 타입 선언들을 해주었습니다.

## 🕰 실제 소요 시간

> 작업을 시작하기 부터 PR을 올리기 까지 소요된 시간입니다.

- 12h
