### PR TITLE
Feature/#48, 53 [FE] 상품 목록 페이지에서 사용할 레이아웃 설정 및 상태 관리 로직 추가

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,6 +8,7 @@ import LoginPage from '~/pages/Login';
 import AlertModal from './components/AlertModal';
 import ConfirmModal from './components/ConfirmModal';
 import MyPage from './pages/MyPage';
+import ProductList from './pages/ProductList';
 
 const Main = styled.main`
   height: 100%;
@@ -26,6 +27,9 @@ const App = () => {
             </Route>
             <Route path="/hello/:name/:number">
               <div>임시 Route</div>
+            </Route>
+            <Route exact path="/products">
+              <ProductList />
             </Route>
             <Route exact path="/me">
               <MyPage />

--- a/client/src/assets/index.tsx
+++ b/client/src/assets/index.tsx
@@ -15,6 +15,7 @@ const S3_PREFIX = 'https:/store-6-bucket.s3.ap-northeast-2.amazonaws.com';
 
 const LogoSVG = `${S3_PREFIX}/common/logo.svg`;
 const LineSVG = `${S3_PREFIX}/common/line.svg`;
+const VertLineSVG = `${S3_PREFIX}/common/vertical-line.svg`;
 
 const DoodleUselessSVG = `${S3_PREFIX}/header/doodle-useless.svg`;
 const HeartSVG = `${S3_PREFIX}/header/heart.svg`;
@@ -48,6 +49,7 @@ const BigCircleSVG = `${S3_PREFIX}/common/big-icon/circle.svg`;
 
 export {
   LogoSVG,
+  VertLineSVG,
   DoodleUselessSVG,
   HeartSVG,
   MypageSVG,

--- a/client/src/components/CategoryFilter/index.tsx
+++ b/client/src/components/CategoryFilter/index.tsx
@@ -1,0 +1,28 @@
+import React, { useContext } from 'react';
+import { FilterContext } from '~/pages/ProductList';
+
+enum CategoryType {
+  Book,
+  Stationery,
+  Living,
+  Green,
+  Baedal,
+  Kkk,
+  Ulgiro,
+  Collaboration,
+  Gift,
+}
+
+const CategoryFilter: React.FC = () => {
+  const { setCategory, ...state } = useContext(FilterContext);
+
+  return (
+    <div>
+      <button type="button" onClick={() => setCategory(CategoryType.Gift)}>
+        sdfsdfsdf
+      </button>
+    </div>
+  );
+};
+
+export default CategoryFilter;

--- a/client/src/components/OrderFilter/index.tsx
+++ b/client/src/components/OrderFilter/index.tsx
@@ -1,0 +1,11 @@
+import React, { FC } from 'react';
+
+const OrderFilter: FC = () => {
+  return (
+    <div>
+      <span>순서 컴포넌트</span>
+    </div>
+  );
+};
+
+export default OrderFilter;

--- a/client/src/lib/api/types/products.ts
+++ b/client/src/lib/api/types/products.ts
@@ -1,9 +1,9 @@
 export interface ProductsGetRequestQuery {
   category?: number;
   search?: string;
-  order?: string;
-  offset?: string;
-  limit?: string;
+  order?: 'recent' | 'low-price' | 'high-price';
+  page: number;
+  limit: number;
 }
 
 export interface ProductsGetResponseBody {

--- a/client/src/pages/ProductList/__snapshots__/index.spec.tsx.snap
+++ b/client/src/pages/ProductList/__snapshots__/index.spec.tsx.snap
@@ -40,10 +40,16 @@ exports[`<ProductList /> should render same with snapshot 1`] = `
       class="c1"
     >
       <div>
-        카테고리 컴포넌트
+        <button
+          type="button"
+        >
+          sdfsdfsdf
+        </button>
       </div>
       <div>
-        순서 컴포넌트
+        <span>
+          순서 컴포넌트
+        </span>
       </div>
     </section>
     <div
@@ -52,9 +58,11 @@ exports[`<ProductList /> should render same with snapshot 1`] = `
     <section
       class="c3"
     >
-      <div>
+      <button
+        type="button"
+      >
         카테고리 현재 선택
-      </div>
+      </button>
       <div>
         검색
       </div>

--- a/client/src/pages/ProductList/__snapshots__/index.spec.tsx.snap
+++ b/client/src/pages/ProductList/__snapshots__/index.spec.tsx.snap
@@ -1,0 +1,70 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ProductList /> should render same with snapshot 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  height: 100%;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c1 {
+  width: 218px;
+  height: 100%;
+}
+
+.c3 {
+  width: 700px;
+  height: 100%;
+}
+
+.c2 {
+  width: 1px;
+  height: 100%;
+  margin: 0 45px;
+  background: url(https:/store-6-bucket.s3.ap-northeast-2.amazonaws.com/common/vertical-line.svg) bottom left no-repeat;
+  background-size: cover;
+}
+
+<div>
+  <div
+    class="c0"
+  >
+    <section
+      class="c1"
+    >
+      <div>
+        카테고리 컴포넌트
+      </div>
+      <div>
+        순서 컴포넌트
+      </div>
+    </section>
+    <div
+      class="c2"
+    />
+    <section
+      class="c3"
+    >
+      <div>
+        카테고리 현재 선택
+      </div>
+      <div>
+        검색
+      </div>
+      <div>
+        상품리스트
+      </div>
+      <div>
+        스크롤
+      </div>
+    </section>
+  </div>
+</div>
+`;

--- a/client/src/pages/ProductList/index.spec.tsx
+++ b/client/src/pages/ProductList/index.spec.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import 'jest-styled-components';
+
+import ProductList from './index';
+
+describe('<ProductList />', () => {
+  it('should render same with snapshot', () => {
+    const { container } = render(<ProductList />);
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/client/src/pages/ProductList/index.style.tsx
+++ b/client/src/pages/ProductList/index.style.tsx
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+import { VertLineSVG } from '~/assets';
+
+export const ProductListWrapper = styled.div`
+  display: flex;
+  width: 100%;
+  height: 100%;
+  justify-content: center;
+`;
+
+export const LeftSection = styled.section`
+  width: 218px;
+  height: 100%;
+`;
+export const RightSection = styled.section`
+  width: 700px;
+  height: 100%;
+`;
+
+export const VerticalDivider = styled.div`
+  width: 1px;
+  height: 100%;
+  margin: 0 45px;
+  background: url(${VertLineSVG}) bottom left no-repeat;
+  background-size: cover;
+`;

--- a/client/src/pages/ProductList/index.tsx
+++ b/client/src/pages/ProductList/index.tsx
@@ -1,0 +1,28 @@
+import React, { FC } from 'react';
+
+import {
+  ProductListWrapper,
+  LeftSection,
+  RightSection,
+  VerticalDivider,
+} from './index.style';
+
+const ProductList: FC = () => {
+  return (
+    <ProductListWrapper>
+      <LeftSection>
+        <div>카테고리 컴포넌트</div>
+        <div>순서 컴포넌트</div>
+      </LeftSection>
+      <VerticalDivider />
+      <RightSection>
+        <div>카테고리 현재 선택</div>
+        <div>검색</div>
+        <div>상품리스트</div>
+        <div>스크롤</div>
+      </RightSection>
+    </ProductListWrapper>
+  );
+};
+
+export default ProductList;

--- a/client/src/pages/ProductList/index.tsx
+++ b/client/src/pages/ProductList/index.tsx
@@ -1,4 +1,12 @@
-import React, { FC } from 'react';
+import React, { FC, createContext } from 'react';
+import CategoryFilter from '~/components/CategoryFilter';
+import OrderFilter from '~/components/OrderFilter';
+import productModule, {
+  CategoryType,
+  DEFAULT_FILTER,
+  OrderType,
+  SearchValueType,
+} from '~/stores/productModule';
 
 import {
   ProductListWrapper,
@@ -7,21 +15,36 @@ import {
   VerticalDivider,
 } from './index.style';
 
+export const FilterContext = createContext({
+  ...DEFAULT_FILTER,
+  setCategory: (_: CategoryType) => {},
+  setOrder: (_: OrderType) => {},
+  setSearchValue: (_: SearchValueType) => {},
+  setPage: () => {},
+});
+
 const ProductList: FC = () => {
+  const { filter, setCategory, setOrder, setSearchValue, setPage } =
+    productModule();
+
   return (
-    <ProductListWrapper>
-      <LeftSection>
-        <div>카테고리 컴포넌트</div>
-        <div>순서 컴포넌트</div>
-      </LeftSection>
-      <VerticalDivider />
-      <RightSection>
-        <div>카테고리 현재 선택</div>
-        <div>검색</div>
-        <div>상품리스트</div>
-        <div>스크롤</div>
-      </RightSection>
-    </ProductListWrapper>
+    <FilterContext.Provider
+      value={{ ...filter, setCategory, setOrder, setSearchValue, setPage }}
+    >
+      <ProductListWrapper>
+        <LeftSection>
+          <CategoryFilter />
+          <OrderFilter />
+        </LeftSection>
+        <VerticalDivider />
+        <RightSection>
+          <button type="button">카테고리 현재 선택</button>
+          <div>검색</div>
+          <div>상품리스트</div>
+          <div>스크롤</div>
+        </RightSection>
+      </ProductListWrapper>
+    </FilterContext.Provider>
   );
 };
 

--- a/client/src/stores/productModule.ts
+++ b/client/src/stores/productModule.ts
@@ -1,0 +1,38 @@
+import { useCallback, useState } from 'react';
+import { ProductsGetRequestQuery } from '~/lib/api/types';
+
+const DEFAULT_PAGE_NUMBER = 1;
+const DEFAULT_PRODUCTS_AMOUNT = 20;
+
+export type CategoryType = ProductsGetRequestQuery['category'];
+export type OrderType = ProductsGetRequestQuery['order'];
+export type SearchValueType = ProductsGetRequestQuery['search'];
+export const DEFAULT_FILTER: ProductsGetRequestQuery = {
+  order: 'recent',
+  page: DEFAULT_PAGE_NUMBER,
+  limit: DEFAULT_PRODUCTS_AMOUNT,
+};
+
+const productModule = () => {
+  const [filter, setFilter] = useState({ ...DEFAULT_FILTER });
+
+  const setCategory = useCallback((category: CategoryType) => {
+    setFilter((prev) => ({ ...prev, category }));
+  }, []);
+
+  const setOrder = useCallback((order: OrderType) => {
+    setFilter((prev) => ({ ...prev, order }));
+  }, []);
+
+  const setSearchValue = useCallback((search: SearchValueType) => {
+    setFilter((prev) => ({ ...prev, search }));
+  }, []);
+
+  const setPage = useCallback(() => {
+    setFilter((prev) => ({ ...prev, page: prev.page + 1 }));
+  }, []);
+
+  return { filter, setCategory, setOrder, setSearchValue, setPage };
+};
+
+export default productModule;

--- a/client/src/styles/app.css
+++ b/client/src/styles/app.css
@@ -10,6 +10,7 @@
   flex-direction: column;
   width: 100%;
   height: 100vh;
+  min-height:1024px;
   align-items: center;
 }
 


### PR DESCRIPTION
## :bookmark_tabs: 제목

### 상품 목록 페이지 레이아웃 작업

<img width="1212" alt="스크린샷 2021-08-18 오후 10 58 32" src="https://user-images.githubusercontent.com/19240202/129911549-453b0f08-c9d7-48e0-8bcf-7fa223b1d1ec.png">

### 상품 목록 페이지 상태 관리 로직 추가

## :paperclip: 관련 이슈

- closes #48 
- closes #53 

## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [ ] Test Code를 작성하였나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 상품 목록 페이지 레이아웃 코드 작성
- [x] Context API 를 사용한 상태 관리 로직 고찰 (노션에 첨부)
- [x] 상태 관리 로직 ~/store/productModule 에 작성

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 상태와 상태 변경 함수를 ~/stores/productModule.ts 에서 관리하고 있는데, 맞는 구조인지 논의가 필요합니다.
- 해당 ts 파일에서 useState, useCallback 훅을 사용하고 있는데 훅이 아님에도 왜 사용 가능한지 이해가 되지 않습니다.
- createContext를 통해 만든 FilterContext는 상품 목록 페이지 최상단 컴포넌트에서 관리하고 있습니다. 이 부분도 맞는 구조인지 논의가 필요합니다.
- Test Code는 우리 합의한 것 처럼 2~30분 봤는데 작성이 어려워 보여 일단 스킵했습니다. 추후에 컴포넌트에서 해당 모듈 함수들을 사용할 경우에는 상태값 비교 테스트를 작성할 수 있을 것 같습니다.

## 🕰 실제 소요 시간

> 작업을 시작하기 부터 PR을 올리기 까지 소요된 시간입니다.

- 7시간
