### PR TITLE
Fix#43 로그아웃 API 함수 호출 시 Header의 토큰 삭제

### DIFF
--- a/client/src/lib/api/auth.ts
+++ b/client/src/lib/api/auth.ts
@@ -16,6 +16,10 @@ const setAuthorizationHeader = (response: AxiosResponse<AuthResponseBody>) => {
   client.defaults.headers.common.Authorization = `Bearer ${access}`;
 };
 
+const clearAuthorizationHeader = () => {
+  client.defaults.headers.common.Authorization = '';
+};
+
 export const login = (reqData: LoginRequestBody) =>
   request<AuthResponseBody, LoginRequestBody>(
     'POST',
@@ -25,6 +29,7 @@ export const login = (reqData: LoginRequestBody) =>
     setAuthorizationHeader,
   );
 
-export const logout = () => request('GET', authUrl.logout);
+export const logout = () =>
+  request('GET', authUrl.logout, null, null, clearAuthorizationHeader);
 
 export const refresh = () => request<AuthResponseBody>('GET', authUrl.refresh);


### PR DESCRIPTION
## :bookmark_tabs: 제목

로그아웃 API 함수 호출 시 Header의 토큰을 삭제합니다.

## :paperclip: 관련 이슈

- closes #43 

## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [X] Warning Message가 발생하지 않았나요?
- [X] Coding Convention을 준수했나요?
## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 로그아웃 API 함수 호출 시 Header의 토큰 삭제

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

ㅎㅎㅎㅎ

## 🕰 실제 소요 시간

> 작업을 시작하기 부터 PR을 올리기 까지 소요된 시간입니다.

- 0.2h
