### PR TITLE
Fix#63 API 요청 함수에서 에러가 return타입에 포함되서 타입추론이 안되는 문제 

### DIFF
--- a/client/src/lib/api/client.ts
+++ b/client/src/lib/api/client.ts
@@ -1,9 +1,7 @@
 import axios from 'axios';
 
 const client = axios.create({
-  validateStatus: (status) => {
-    return status < 500;
-  },
+  validateStatus: () => true,
 });
 
 client.defaults.baseURL = process.env.API_URL ?? '/';

--- a/client/src/lib/api/request.ts
+++ b/client/src/lib/api/request.ts
@@ -21,7 +21,7 @@ const request = async <RES = unknown, REQ = null, PARAMS = null>(
   params?: PARAMS,
   successCallback?: (response: AxiosResponse<RES>) => void,
   failureCallback?: (response: AxiosResponse<ErrorResponseBody>) => void,
-): Promise<ApiResponse<RES> | ErrorResponse> => {
+): Promise<ApiResponse<RES>> => {
   const response = (await client({
     method,
     url,
@@ -41,7 +41,7 @@ const request = async <RES = unknown, REQ = null, PARAMS = null>(
       const axiosErrorResponse = response as AxiosResponse<ErrorResponseBody>;
       failureCallback(axiosErrorResponse);
     }
-    return errorResponse;
+    throw errorResponse;
   }
 
   if (successCallback) {

--- a/client/src/lib/api/request.ts
+++ b/client/src/lib/api/request.ts
@@ -31,17 +31,13 @@ const request = async <RES = unknown, REQ = null, PARAMS = null>(
 
   const { status, data } = response;
   if (response.status >= 400) {
-    const errorData = data as ErrorResponseBody;
-    const errorResponse: ErrorResponse = {
-      statusCode: status,
-      data: errorData,
-    };
-
     if (failureCallback) {
       const axiosErrorResponse = response as AxiosResponse<ErrorResponseBody>;
       failureCallback(axiosErrorResponse);
     }
-    throw errorResponse;
+
+    const errorData = data as ErrorResponseBody;
+    throw new ErrorResponse(response.status, errorData);
   }
 
   if (successCallback) {

--- a/client/src/lib/api/types/error.ts
+++ b/client/src/lib/api/types/error.ts
@@ -7,4 +7,25 @@ export interface ErrorResponseBody {
   stack?: string;
 }
 
-export type ErrorResponse = ApiResponse<ErrorResponseBody>;
+export class ErrorResponse
+  extends Error
+  implements ApiResponse<ErrorResponseBody>
+{
+  isApiRequestFailed: boolean;
+
+  statusCode: number;
+
+  data: ErrorResponseBody;
+
+  constructor(statusCode: number, errorResponseBody: ErrorResponseBody) {
+    super(errorResponseBody.message);
+    this.statusCode = statusCode;
+
+    this.isApiRequestFailed = true;
+
+    // 오류가 발생한 위치에 대한 적절한 스택 추적을 유지합니다(V8에서만 사용 가능)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ErrorResponse);
+    }
+  }
+}


### PR DESCRIPTION
## :bookmark_tabs: 제목

ErrorResponse의 경우 return 하는 게 아니라 throw하도록 수정했습니다.

## :paperclip: 관련 이슈

- closes #63 

## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [X] Warning Message가 발생하지 않았나요?
- [X] Coding Convention을 준수했나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] Error Response는 throw하도록 수정
- [X] axios 에러는 모두 무시하도록 하고 직접 핸들링하도록 수정 

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- None

## 🕰 실제 소요 시간

> 작업을 시작하기 부터 PR을 올리기 까지 소요된 시간입니다.

- 0.5h
