### PR TITLE
Feature/#92 [FE] 자동 로그인 로직 구현

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,6 +10,8 @@ import ConfirmModal from './components/modal/ConfirmModal';
 import MyPage from './pages/MyPage';
 import ProductList from './pages/ProductList';
 import MainPage from './pages/Main';
+import useAutoLogin from './lib/hooks/useAutoLogin';
+import UserContext from './lib/contexts/userContext';
 
 const Main = styled.main`
   position: relative;
@@ -18,35 +20,41 @@ const Main = styled.main`
 `;
 
 const App = () => {
+  const [user, setUser, requestError] = useAutoLogin();
+
+  console.log(user, requestError);
+
   return (
     <>
-      <BrowserRouter>
-        <Navigation />
-        <Main>
-          <Switch>
-            <Route exact path="/">
-              <MainPage />
-            </Route>
-            <Route exact path="/login">
-              <LoginPage />
-            </Route>
-            <Route exact path="/signup">
-              <SignUpPage />
-            </Route>
-            <Route path="/hello/:name/:number">
-              <div>임시 Route</div>
-            </Route>
-            <Route exact path="/products">
-              <ProductList />
-            </Route>
-            <Route exact path="/me">
-              <MyPage />
-            </Route>
-          </Switch>
-        </Main>
-      </BrowserRouter>
-      <AlertModal />
-      <ConfirmModal />
+      <UserContext.Provider value={{ user, setUser }}>
+        <BrowserRouter>
+          <Navigation />
+          <Main>
+            <Switch>
+              <Route exact path="/">
+                <MainPage />
+              </Route>
+              <Route exact path="/login">
+                <LoginPage />
+              </Route>
+              <Route exact path="/signup">
+                <SignUpPage />
+              </Route>
+              <Route path="/hello/:name/:number">
+                <div>임시 Route</div>
+              </Route>
+              <Route exact path="/products">
+                <ProductList />
+              </Route>
+              <Route exact path="/me">
+                <MyPage />
+              </Route>
+            </Switch>
+          </Main>
+        </BrowserRouter>
+        <AlertModal />
+        <ConfirmModal />
+      </UserContext.Provider>
     </>
   );
 };

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,5 @@
-import React, { FC, createContext } from 'react';
 import styled from 'styled-components';
-import { BrowserRouter, Switch, Route } from '~/core/Router';
+import { Switch, Route } from '~/core/Router';
 import '~/styles/app.css';
 import Navigation from '~/components/base/Navigation';
 import LoginPage from '~/pages/Login';
@@ -10,8 +9,6 @@ import ConfirmModal from './components/modal/ConfirmModal';
 import MyPage from './pages/MyPage';
 import ProductList from './pages/ProductList';
 import MainPage from './pages/Main';
-import useAutoLogin from './lib/hooks/useAutoLogin';
-import UserContext from './lib/contexts/userContext';
 
 const Main = styled.main`
   position: relative;
@@ -20,41 +17,33 @@ const Main = styled.main`
 `;
 
 const App = () => {
-  const [user, setUser, requestError] = useAutoLogin();
-
-  console.log(user, requestError);
-
   return (
     <>
-      <UserContext.Provider value={{ user, setUser }}>
-        <BrowserRouter>
-          <Navigation />
-          <Main>
-            <Switch>
-              <Route exact path="/">
-                <MainPage />
-              </Route>
-              <Route exact path="/login">
-                <LoginPage />
-              </Route>
-              <Route exact path="/signup">
-                <SignUpPage />
-              </Route>
-              <Route path="/hello/:name/:number">
-                <div>임시 Route</div>
-              </Route>
-              <Route exact path="/products">
-                <ProductList />
-              </Route>
-              <Route exact path="/me">
-                <MyPage />
-              </Route>
-            </Switch>
-          </Main>
-        </BrowserRouter>
-        <AlertModal />
-        <ConfirmModal />
-      </UserContext.Provider>
+      <Navigation />
+      <Main>
+        <Switch>
+          <Route exact path="/">
+            <MainPage />
+          </Route>
+          <Route exact path="/login">
+            <LoginPage />
+          </Route>
+          <Route exact path="/signup">
+            <SignUpPage />
+          </Route>
+          <Route path="/hello/:name/:number">
+            <div>임시 Route</div>
+          </Route>
+          <Route exact path="/products">
+            <ProductList />
+          </Route>
+          <Route exact path="/me">
+            <MyPage />
+          </Route>
+        </Switch>
+      </Main>
+      <AlertModal />
+      <ConfirmModal />
     </>
   );
 };

--- a/client/src/Root.tsx
+++ b/client/src/Root.tsx
@@ -7,9 +7,9 @@ const Root = () => {
   const [user, setUser] = useAutoLogin();
 
   return (
-    <UserContext.Provider value={{user, setUser}}>
+    <UserContext.Provider value={{ user, setUser }}>
       <BrowserRouter>
-        <App/>
+        <App />
       </BrowserRouter>
     </UserContext.Provider>
   );

--- a/client/src/Root.tsx
+++ b/client/src/Root.tsx
@@ -1,0 +1,18 @@
+import App from './App';
+import { BrowserRouter } from './core/Router';
+import UserContext from './lib/contexts/userContext';
+import useAutoLogin from './lib/hooks/useAutoLogin';
+
+const Root = () => {
+  const [user, setUser] = useAutoLogin();
+
+  return (
+    <UserContext.Provider value={{user, setUser}}>
+      <BrowserRouter>
+        <App/>
+      </BrowserRouter>
+    </UserContext.Provider>
+  );
+};
+
+export default Root;

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
 import ReactDOM from 'react-dom';
-import App from './App';
+import Root from './Root';
 
-ReactDOM.render(<App />, document.getElementById('app'));
+ReactDOM.render(<Root />, document.getElementById('app'));

--- a/client/src/lib/contexts/createNamedContext.ts
+++ b/client/src/lib/contexts/createNamedContext.ts
@@ -1,6 +1,9 @@
 import { createContext } from 'react';
 
-const createNamedContext = <T = unknown>(name: string, defaultValue: T = null) => {
+const createNamedContext = <T = unknown>(
+  name: string,
+  defaultValue: T = null,
+) => {
   const context = createContext<T>(defaultValue);
   context.displayName = name;
 

--- a/client/src/lib/contexts/createNamedContext.ts
+++ b/client/src/lib/contexts/createNamedContext.ts
@@ -1,0 +1,10 @@
+import { createContext } from 'react';
+
+const createNamedContext = <T = unknown>(name: string, defaultValue: T = null) => {
+  const context = createContext<T>(defaultValue);
+  context.displayName = name;
+
+  return context;
+};
+
+export default createNamedContext;

--- a/client/src/lib/contexts/userContext.ts
+++ b/client/src/lib/contexts/userContext.ts
@@ -1,6 +1,6 @@
-import { Dispatch, SetStateAction  } from "react";
-import { UsersGetResponseBody } from "../api/types";
-import createNamedContext from "./createNamedContext";
+import { Dispatch, SetStateAction } from 'react';
+import { UsersGetResponseBody } from '../api/types';
+import createNamedContext from './createNamedContext';
 
 export interface UserContextState {
   user: UsersGetResponseBody;

--- a/client/src/lib/contexts/userContext.ts
+++ b/client/src/lib/contexts/userContext.ts
@@ -1,0 +1,12 @@
+import { Dispatch, SetStateAction  } from "react";
+import { UsersGetResponseBody } from "../api/types";
+import createNamedContext from "./createNamedContext";
+
+export interface UserContextState {
+  user: UsersGetResponseBody;
+  setUser: Dispatch<SetStateAction<UsersGetResponseBody>>;
+}
+
+const UserContext = createNamedContext<UserContextState>('UserContext');
+
+export default UserContext;

--- a/client/src/lib/hooks/useAutoLogin.ts
+++ b/client/src/lib/hooks/useAutoLogin.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+import * as authApi from '~/lib/api/auth';
+import * as usersApi from '~/lib/api/users';
+import {
+  ErrorResponse,
+  ErrorResponseBody,
+  UsersGetResponseBody,
+} from '../api/types';
+
+const useAutoLogin = () => {
+  const [requestError, setRequestError] = useState<ErrorResponseBody>(null);
+  const [user, setUser] = useState<UsersGetResponseBody>(null);
+
+  useEffect(() => {
+    authApi
+      .refresh()
+      .then(() => usersApi.getMe())
+      .then((response) => {
+        setUser(response.data);
+      })
+      .catch((error: ErrorResponse) => {
+        setRequestError(error.data);
+      });
+  }, [setUser, setRequestError]);
+
+  return [user, setUser, requestError] as const;
+};
+
+export default useAutoLogin;

--- a/client/src/lib/hooks/useInputValidator.ts
+++ b/client/src/lib/hooks/useInputValidator.ts
@@ -1,10 +1,10 @@
 import { useState, useCallback, DependencyList } from 'react';
 
-function useInputValidator(
+const useInputValidator = (
   initialValue: string,
   validator: (userInput: string) => string,
   deps: DependencyList = [],
-) {
+) => {
   const [input, setInput] = useState(initialValue);
   const [warning, setWarning] = useState(' ');
 
@@ -17,6 +17,6 @@ function useInputValidator(
     onInput(ev.target.value);
   }, deps);
   return [input, warning, handleInput] as const;
-}
+};
 
 export default useInputValidator;

--- a/client/src/lib/hooks/useOnClickOutside.ts
+++ b/client/src/lib/hooks/useOnClickOutside.ts
@@ -2,10 +2,10 @@ import { useEffect, RefObject } from 'react';
 
 type AnyEvent = MouseEvent | TouchEvent;
 
-function useOnClickOutside<T extends HTMLElement = HTMLElement>(
+const useOnClickOutside = <T extends HTMLElement = HTMLElement>(
   ref: RefObject<T>,
   handler: (event: AnyEvent) => void,
-) {
+) => {
   useEffect(() => {
     const listener = (event: AnyEvent) => {
       const el = ref?.current;
@@ -28,6 +28,6 @@ function useOnClickOutside<T extends HTMLElement = HTMLElement>(
 
     // Reload only if ref or handler changes
   }, [ref, handler]);
-}
+};
 
 export default useOnClickOutside;

--- a/client/src/lib/hooks/useUser.ts
+++ b/client/src/lib/hooks/useUser.ts
@@ -1,0 +1,9 @@
+import { useContext } from 'react';
+import UserContext from '../contexts/userContext';
+
+const useUser = () => {
+  const { user, setUser } = useContext(UserContext);
+  return [user, setUser] as const;
+};
+
+export default useUser;

--- a/server/src/service/auth.ts
+++ b/server/src/service/auth.ts
@@ -4,7 +4,7 @@ import * as hashHelper from '@/helper/hash';
 import * as jwtHelper from '@/helper/jwt';
 import * as authHelper from '@/helper/auth';
 import ErrorResponse from '@/utils/errorResponse';
-import { commonError, loginError, logoutError } from '@/constants/error';
+import { commonError, loginError, logoutError, refreshError } from '@/constants/error';
 import LoginRepository from '@/repository/login';
 
 @Service()
@@ -55,6 +55,9 @@ class AuthService {
 
   async RefreshAccessToken(refreshToken: string) {
     try {
+      if (!refreshToken) {
+        throw new ErrorResponse(commonError.unauthorized);
+      }
       const { idx } = jwtHelper.decodeRefreshToken(refreshToken);
       const login = await this.loginRepository.findByIdx(idx);
       const isValid = await authHelper.verifyRefreshToken(refreshToken, idx);
@@ -65,10 +68,10 @@ class AuthService {
 
       throw new ErrorResponse(commonError.unauthorized);
     } catch (e) {
-      if (e instanceof ErrorResponse) {
+      if (e?.isOperational) {
         throw e;
       }
-      throw new ErrorResponse(loginError.unable);
+      throw new ErrorResponse(refreshError.unable);
     }
   }
 }


### PR DESCRIPTION
## :bookmark_tabs: 제목

초기 로딩 시 refresh API를 호출하고 성공 시 사용자 정보를 가져오는 API를 호출하는 자동 로그인을 구현했습니다.

## :paperclip: 관련 이슈

- closes #92 

## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [X] Warning Message가 발생하지 않았나요?
- [X] Coding Convention을 준수했나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] hook 함수들 .ts로 확장자 사용 및 화살표 함수로 변경
- [x] UserContext 추가
- [x] UserContext 사용하는 useUser hook 추가
- [x] refresh API & getMe API 호출하는 useAutoLogin hook 추가
- [x] 자동 로그인으로 가져온 사용자 정보를 UserContext에 저장
- [x]서버 쪽 auth service refresh method 에러 처리 수정

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- useAutoLogin hook을 사용하게 되면 해당 컴포넌트가 마운트 될 때 자동 로그인을 위한 API 요청을 시작합니다.
- API 요청이 끝나면 useAutoLogin 내 상태로 결과(user info)를 저장합니다.
- 사용자 정보를 UserContext에 담고 UserContext.Provider를 App 컴포넌트 최상단에 추가했습니다.

## 🕰 실제 소요 시간

> 작업을 시작하기 부터 PR을 올리기 까지 소요된 시간입니다.

- 1h
