### PR TITLE
Bug/#100 쿠키 관련 요청 시 쿠키가 설정되지 않는 문제 해결

### DIFF
--- a/client/src/lib/api/auth.ts
+++ b/client/src/lib/api/auth.ts
@@ -32,4 +32,11 @@ export const login = (reqData: LoginRequestBody) =>
 export const logout = () =>
   request('GET', authUrl.logout, null, null, clearAuthorizationHeader);
 
-export const refresh = () => request<AuthResponseBody>('GET', authUrl.refresh);
+export const refresh = () =>
+  request<AuthResponseBody>(
+    'GET',
+    authUrl.refresh,
+    null,
+    null,
+    setAuthorizationHeader,
+  );

--- a/client/src/lib/api/request.ts
+++ b/client/src/lib/api/request.ts
@@ -26,6 +26,7 @@ const request = async <RES = unknown, REQ = null, PARAMS = null>(
     method,
     url,
     params,
+    withCredentials: true,
     ...(body && { data: body }),
   })) as AxiosResponse<RES | ErrorResponseBody>;
 

--- a/server/src/loaders/express.ts
+++ b/server/src/loaders/express.ts
@@ -11,12 +11,14 @@ import { commonError } from '@/constants/error';
 export default (app: Express) => {
   app.use(express.json());
   app.use(express.urlencoded({ extended: true }));
-  app.use(
-    cors({
-      origin: true,
-      credentials: true,
-    }),
-  );
+  if (process.env.NODE_ENV === 'development') {
+    app.use(
+      cors({
+        origin: true,
+        credentials: true,
+      }),
+    );
+  }
   app.use(cookieParser());
   app.use(morgan(process.env.NODE_ENV === 'development' ? 'dev' : 'combined'));
 

--- a/server/src/loaders/express.ts
+++ b/server/src/loaders/express.ts
@@ -11,7 +11,12 @@ import { commonError } from '@/constants/error';
 export default (app: Express) => {
   app.use(express.json());
   app.use(express.urlencoded({ extended: true }));
-  app.use(cors());
+  app.use(
+    cors({
+      origin: true,
+      credentials: true,
+    }),
+  );
   app.use(cookieParser());
   app.use(morgan(process.env.NODE_ENV === 'development' ? 'dev' : 'combined'));
 

--- a/server/src/service/auth.ts
+++ b/server/src/service/auth.ts
@@ -4,7 +4,12 @@ import * as hashHelper from '@/helper/hash';
 import * as jwtHelper from '@/helper/jwt';
 import * as authHelper from '@/helper/auth';
 import ErrorResponse from '@/utils/errorResponse';
-import { commonError, loginError, logoutError, refreshError } from '@/constants/error';
+import {
+  commonError,
+  loginError,
+  logoutError,
+  refreshError,
+} from '@/constants/error';
 import LoginRepository from '@/repository/login';
 
 @Service()


### PR DESCRIPTION
## :bookmark_tabs: 제목

쿠키 관련 요청 시 쿠키가 설정되지 않는 문제 해결

## :paperclip: 관련 이슈

- closes #100 

## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [X] Warning Message가 발생하지 않았나요?
- [X] Coding Convention을 준수했나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 다른 도메인 쿠키 설정 허용을 위해 client 쪽 요청 시 withCredentials 옵션 true로 설정
- [x] 서버쪽 cors 설정에 credentials와 origin 옵션을 true로 설정
- [x] 서버쪽 cors를 NODE_ENV가 development 일 때만 허용하도록 수정

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 기존에는 서버쪽 cors 설정을 production에서도  설정하고 있었는 데 development 일 때만 허용해주도록 수정했습니다. 배포 시에는 같은 도메인에서 배포되니까 보안상의 문제가 발생할 수 있다고 생각했습니다.
- production 환경에서의 테스트는 로컬에서 하기 어려운 부분이 있어서 현재 진행하지 못했습니다. 배포할 때 이 부분 확인해야 하고 문제가 생겨도 몇 줄만 수정하면 되니까 크게 문제는 생기지 않을 거라 생각합니다.

## 🕰 실제 소요 시간

> 작업을 시작하기 부터 PR을 올리기 까지 소요된 시간입니다.

- 0.25h(15m)
