### PR TITLE
Bug/#105 페이지 새로고침 시 aunthorized 에러 및 이미지 업로드 에러

### DIFF
--- a/client/src/components/cart/cart/index.tsx
+++ b/client/src/components/cart/cart/index.tsx
@@ -1,7 +1,8 @@
-import React, { FC, useState, useEffect } from 'react';
+import { FC, useState, useEffect } from 'react';
 import Button from '~/components/common/Button';
 import Divider from '~/components/common/Divider';
 import { deleteCartItem, getCartItems } from '~/lib/api/cart';
+import useUser from '~/lib/hooks/useUser';
 import { alert } from '~/utils/modal';
 import CartItem from '../cartItem';
 import { CartFooter, CartHeader } from './index.style';
@@ -9,6 +10,7 @@ import { CartFooter, CartHeader } from './index.style';
 const Cart: FC = () => {
   const [cartItems, setCartItems] = useState([]);
   const [amount, setAmount] = useState(0);
+  const [user] = useUser();
 
   const calAmount = (items) => {
     return items.reduce((acc, cur) => {
@@ -25,8 +27,10 @@ const Cart: FC = () => {
   };
 
   useEffect(() => {
-    fetchCart();
-  }, []);
+    if (user) {
+      fetchCart();
+    }
+  }, [user]);
 
   const onSubmit = () => {
     alert('결제기능은 준비되지 않았습니다.');

--- a/client/src/lib/api/types/users.ts
+++ b/client/src/lib/api/types/users.ts
@@ -23,6 +23,6 @@ export interface UsersPutRequestBody {
   password?: string;
   email?: string;
   phone?: string;
-  img?: File;
+  profile?: File;
 }
 export type UsersPutResponseBody = UpdateInfo;

--- a/client/src/lib/hooks/useUser.ts
+++ b/client/src/lib/hooks/useUser.ts
@@ -2,7 +2,13 @@ import { useContext } from 'react';
 import UserContext from '../contexts/userContext';
 
 const useUser = () => {
-  const { user, setUser } = useContext(UserContext);
+  const userContext = useContext(UserContext);
+
+  if (!userContext) {
+    return [null, null];
+  }
+
+  const { user, setUser } = userContext;
   return [user, setUser] as const;
 };
 

--- a/client/src/pages/MyPage/index.tsx
+++ b/client/src/pages/MyPage/index.tsx
@@ -26,6 +26,7 @@ import {
   ImageDesc,
   ImageInput,
 } from './index.style';
+import useUser from '~/lib/hooks/useUser';
 
 const message = {
   EMAIL_UPDATE_SUCCESS: '이메일이 수정되었습니다.',
@@ -41,7 +42,7 @@ const MyPage: React.FC = () => {
     'https://user-images.githubusercontent.com/47776356/129712816-13701b24-57cc-451e-93c6-ca7afe190af1.jpeg',
   );
 
-  const [userInfo, setUserInfo] = useState<UsersGetResponseBody | null>(null);
+  const [userInfo, setUserInfo] = useUser();
   const imagePreviewRef: RefObject<HTMLLabelElement> = useRef();
 
   const handleSubmitEmail = async (value: string) => {
@@ -62,7 +63,7 @@ const MyPage: React.FC = () => {
 
   const handleSubmitProfile = async (file, fileToString) => {
     const response = await putMe({
-      img: file,
+      profile: file,
     });
 
     if (response.statusCode === 200) {
@@ -97,27 +98,10 @@ const MyPage: React.FC = () => {
   }, [imagePreviewRef, profile]);
 
   useEffect(() => {
-    const fetchUser = async () => {
-      // 로그인 기능이 아직 구현되어있지 않아, 테스트를 위해 로그인 로직을 추가해놓았습니다.
-      // const test = await login({
-      //   id: 'test',
-      //   password: 'hahahahoho',
-      // });
-
-      const response = await getMe();
-
-      if (response.statusCode === 200) {
-        const user = response.data as UsersGetResponseBody;
-
-        if (user.profile) {
-          setProfile(user.profile);
-        }
-
-        setUserInfo(user);
-      }
-    };
-    fetchUser();
-  }, []);
+    if (userInfo?.profile) {
+      setProfile(userInfo.profile);
+    }
+  }, [userInfo]);
 
   return (
     <StyledMyPage>


### PR DESCRIPTION
## :bookmark_tabs: 제목

마운트 시 데이터를 패칭하는 페이지에서 에러가 발생했습니다.
이미지 업로드가 되지 않는 버그가 발생했습니다.

## :paperclip: 관련 이슈

- closes #105 

## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [X] Warning Message가 발생하지 않았나요?
- [X] Coding Convention을 준수했나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] img 필드 이름을 profile로 변경
- [x] 마이페이지에서 사용자 정보를 요청하기보다 useUser hook 사용
- [x] 장바구니 페이지에서 useUser hook 사용해서 user가 있을 때 요청 보내도록 수정

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 호옥시 사용자 정보를 가져오기 위해서 직접 요청을 보내고 있으시다면 useUser hook을 사용해주세요
- 마이페이지처럼 사용자 정보를 수정할 때는 useUser hook으로 가져온 setUser로!
- 사용자 정보가 있어야 할 떄는 useUser hook으로 가져온 user값이 있을 때 동작 수행하도록 작성해주세요
## 🕰 실제 소요 시간

> 작업을 시작하기 부터 PR을 올리기 까지 소요된 시간입니다.

- 15m
