### PR TITLE
Feature/#102 [BE] Oauth Login API 구현

### DIFF
--- a/server/.lintstagedrc.json
+++ b/server/.lintstagedrc.json
@@ -1,0 +1,4 @@
+{
+  "*.{js,ts}": ["eslint --fix", "prettier --write"],
+  "*.{json,md}": ["prettier --write"]
+}

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,7 @@
     "start": "env-cmd ts-node -r tsconfig-paths/register ./src/bin/www.ts",
     "lint:fix": "eslint --fix .",
     "prettier:write": "prettier --write .",
-    "precommit": "yarn lint:fix && yarn prettier:write",
+    "precommit": "yarn lint-staged",
     "test": "env-cmd -f .env.dev jest --detectOpenHandles --forceExit",
     "coverage": "env-cmd -f .env.dev jest --coverage --detectOpenHandles --forceExit"
   },
@@ -35,6 +35,7 @@
     "eslint-plugin-import": "^2.23.4",
     "eslint-plugin-prettier": "^3.4.0",
     "jest": "^27.0.6",
+    "lint-staged": "^11.1.2",
     "nodemon": "^2.0.12",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.3.2",

--- a/server/src/api/routes/oauth/index.ts
+++ b/server/src/api/routes/oauth/index.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import {
   handleOauthFacebook,
   handleOauthFacebookCallback,
+  handleOauthFacebookLogin,
   handleOauthGoogle,
   handleOauthGoogleCallback,
   handleOauthGoogleLogin,
@@ -17,6 +18,7 @@ export default (router: Router) => {
   oauthRouter.get('/google/callback', handleOauthGoogleCallback);
 
   oauthRouter.get('/facebook', handleOauthFacebook);
+  oauthRouter.get('/facebook/login', handleOauthFacebookLogin);
   oauthRouter.get('/facebook/callback', handleOauthFacebookCallback);
 
   return router;

--- a/server/src/api/routes/oauth/index.ts
+++ b/server/src/api/routes/oauth/index.ts
@@ -4,6 +4,7 @@ import {
   handleOauthFacebookCallback,
   handleOauthGoogle,
   handleOauthGoogleCallback,
+  handleOauthGoogleLogin,
 } from './oauthController';
 
 const oauthRouter = Router();
@@ -12,6 +13,7 @@ export default (router: Router) => {
   router.use('/oauth', oauthRouter);
 
   oauthRouter.get('/google', handleOauthGoogle);
+  oauthRouter.get('/google/login', handleOauthGoogleLogin);
   oauthRouter.get('/google/callback', handleOauthGoogleCallback);
 
   oauthRouter.get('/facebook', handleOauthFacebook);

--- a/server/src/api/routes/oauth/oauthController.ts
+++ b/server/src/api/routes/oauth/oauthController.ts
@@ -1,6 +1,7 @@
 import { NextFunction, Request, Response } from 'express';
 import { Container } from 'typeorm-typedi-extensions';
 import * as oauthHelper from '@/helper/oauth';
+import * as jwtHelper from '@/helper/jwt';
 import OAuthService from '@/service/oauth';
 import ErrorResponse from '@/utils/errorResponse';
 import { commonError } from '@/constants/error';
@@ -11,7 +12,25 @@ export const handleOauthGoogle = (
   next: NextFunction,
 ) => {
   try {
-    res.redirect(oauthHelper.getOauthGoogleRedirectUrl());
+    const csrfToken = Math.random().toString(36).substring(7);
+    res.cookie('X-CSRF-Token', csrfToken, { maxAge: 60000 });
+
+    res.redirect(oauthHelper.getOauthGoogleRedirectUrl(false, csrfToken));
+  } catch (e) {
+    next(e);
+  }
+};
+
+export const handleOauthGoogleLogin = (
+  _req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const csrfToken = Math.random().toString(36).substring(7);
+    res.cookie('X-CSRF-Token', csrfToken, { maxAge: 60000 });
+
+    res.redirect(oauthHelper.getOauthGoogleRedirectUrl(true, csrfToken));
   } catch (e) {
     next(e);
   }
@@ -23,7 +42,14 @@ export const handleOauthGoogleCallback = async (
   next: NextFunction,
 ) => {
   try {
-    const { code } = req.query;
+    const { code, state } = req.query;
+    const csrfToken = req.cookies['X-CSRF-Token'];
+    const decodedState = oauthHelper.oauthStateDecoder(state as string);
+
+    if (csrfToken !== decodedState.csrf_token) {
+      throw new ErrorResponse(commonError.invalidState);
+    }
+    res.clearCookie('X-CSRF-Token');
 
     if (!code) {
       throw new ErrorResponse(commonError.invalidQuery);
@@ -31,14 +57,27 @@ export const handleOauthGoogleCallback = async (
 
     const oauthServiceInstance = Container.get(OAuthService);
 
-    const accessToken = await oauthServiceInstance.getGoogleAccessToken(
+    const oauthAccessToken = await oauthServiceInstance.getGoogleAccessToken(
       code as string,
     );
     const { id, email, picture } = await oauthServiceInstance.getGoogleUserInfo(
-      accessToken,
+      oauthAccessToken,
     );
 
-    res.json({ id, email, picture });
+    if (decodedState?.is_login_request !== 'true') {
+      res.json({ id, email, picture });
+      return;
+    }
+
+    const { access, refresh } = await oauthServiceInstance.googleLogin(id);
+
+    res.cookie('X-Refresh-Token', refresh, {
+      expires: new Date(Date.now() + jwtHelper.getRefreshExpiresInMs()),
+      secure: false,
+      httpOnly: true,
+    });
+
+    res.status(200).json({ access });
   } catch (e) {
     next(e);
   }

--- a/server/src/api/routes/oauth/oauthController.ts
+++ b/server/src/api/routes/oauth/oauthController.ts
@@ -49,7 +49,6 @@ export const handleOauthGoogleCallback = async (
     if (csrfToken !== decodedState.csrf_token) {
       throw new ErrorResponse(commonError.invalidState);
     }
-    res.clearCookie('X-CSRF-Token');
 
     if (!code) {
       throw new ErrorResponse(commonError.invalidQuery);
@@ -89,7 +88,25 @@ export const handleOauthFacebook = (
   next: NextFunction,
 ) => {
   try {
-    res.redirect(oauthHelper.getOauthFacebookRedirectUrl());
+    const csrfToken = Math.random().toString(36).substring(7);
+    res.cookie('X-CSRF-Token', csrfToken, { maxAge: 60000 });
+
+    res.redirect(oauthHelper.getOauthFacebookRedirectUrl(false, csrfToken));
+  } catch (e) {
+    next(e);
+  }
+};
+
+export const handleOauthFacebookLogin = (
+  _req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const csrfToken = Math.random().toString(36).substring(7);
+    res.cookie('X-CSRF-Token', csrfToken, { maxAge: 60000 });
+
+    res.redirect(oauthHelper.getOauthFacebookRedirectUrl(true, csrfToken));
   } catch (e) {
     next(e);
   }
@@ -101,7 +118,13 @@ export const handleOauthFacebookCallback = async (
   next: NextFunction,
 ) => {
   try {
-    const { code } = req.query;
+    const { code, state } = req.query;
+    const csrfToken = req.cookies['X-CSRF-Token'];
+    const decodedState = oauthHelper.oauthStateDecoder(state as string);
+
+    if (csrfToken !== decodedState.csrf_token) {
+      throw new ErrorResponse(commonError.invalidState);
+    }
 
     if (!code) {
       throw new ErrorResponse(commonError.invalidQuery);
@@ -109,13 +132,26 @@ export const handleOauthFacebookCallback = async (
 
     const oauthServiceInstance = Container.get(OAuthService);
 
-    const accessToken = await oauthServiceInstance.getFacebookAccessToken(
+    const oauthAccessToken = await oauthServiceInstance.getFacebookAccessToken(
       code as string,
     );
     const { id, email, picture } =
-      await oauthServiceInstance.getFacebookUserInfo(accessToken);
+      await oauthServiceInstance.getFacebookUserInfo(oauthAccessToken);
 
-    res.json({ id, email, picture });
+    if (decodedState?.is_login_request !== 'true') {
+      res.json({ id, email, picture });
+      return;
+    }
+
+    const { access, refresh } = await oauthServiceInstance.googleLogin(id);
+
+    res.cookie('X-Refresh-Token', refresh, {
+      expires: new Date(Date.now() + jwtHelper.getRefreshExpiresInMs()),
+      secure: false,
+      httpOnly: true,
+    });
+
+    res.status(200).json({ access });
   } catch (e) {
     next(e);
   }

--- a/server/src/constants/error.ts
+++ b/server/src/constants/error.ts
@@ -27,6 +27,10 @@ export const commonError = {
     statusCode: 400,
     message: 'Invalid query parameters',
   },
+  invalidState: {
+    statusCode: 422,
+    message: 'Invalid state',
+  },
 };
 
 export const uploadImageError = {

--- a/server/src/constants/login.ts
+++ b/server/src/constants/login.ts
@@ -1,5 +1,0 @@
-export enum LoginType {
-  Own = 'OWN',
-  Facebook = 'FACEBOOK',
-  Google = 'GOOGLE',
-}

--- a/server/src/constants/login.ts
+++ b/server/src/constants/login.ts
@@ -1,0 +1,5 @@
+export enum LoginType {
+  Own = 'OWN',
+  Facebook = 'FACEBOOK',
+  Google = 'GOOGLE',
+}

--- a/server/src/entity/login.ts
+++ b/server/src/entity/login.ts
@@ -6,7 +6,12 @@ import {
   UpdateDateColumn,
   Unique,
 } from 'typeorm';
-import { LoginType } from '@/constants/login';
+
+export enum LoginType {
+  Own = 'OWN',
+  Facebook = 'FACEBOOK',
+  Google = 'GOOGLE',
+}
 
 @Entity({ name: 'login' })
 @Unique(['id', 'type'])

--- a/server/src/entity/login.ts
+++ b/server/src/entity/login.ts
@@ -4,14 +4,16 @@ import {
   Column,
   CreateDateColumn,
   UpdateDateColumn,
+  Unique,
 } from 'typeorm';
 
 @Entity({ name: 'login' })
+@Unique(['id', 'type'])
 class LoginEntity {
   @PrimaryGeneratedColumn()
   idx: number;
 
-  @Column({ length: 45, unique: true })
+  @Column({ length: 45 })
   id: string;
 
   @Column('text')

--- a/server/src/entity/login.ts
+++ b/server/src/entity/login.ts
@@ -6,6 +6,7 @@ import {
   UpdateDateColumn,
   Unique,
 } from 'typeorm';
+import { LoginType } from '@/constants/login';
 
 @Entity({ name: 'login' })
 @Unique(['id', 'type'])
@@ -19,7 +20,7 @@ class LoginEntity {
   @Column('text')
   password: string;
 
-  @Column({ length: 20, default: 'OWN' })
+  @Column({ length: 20, default: LoginType.Own })
   type: string;
 
   @CreateDateColumn({ type: 'timestamp' })

--- a/server/src/helper/oauth.ts
+++ b/server/src/helper/oauth.ts
@@ -35,11 +35,41 @@ export interface OauthFacebookInfoResponse {
   };
 }
 
-export const getOauthGoogleRedirectUrl = () => {
+export const oauthStateDecoder = (state: string) => {
+  const result: Record<string, string> = {};
+  const splittedState = state.split('&').map(v => v.split('='));
+  splittedState.forEach(([key, value]) => {
+    result[key] = value;
+  });
+  return result;
+};
+
+export const oauthStateEncoder = (state: object) => {
+  const urlEscapeMap = {
+    '=': '%3D',
+    '&': '%26',
+  };
+  return Object.entries(state)
+    .reduce(
+      (acc, cur) =>
+        `${acc}${cur[0]}${urlEscapeMap['=']}${cur[1]}${urlEscapeMap['&']}`,
+      '',
+    )
+    .slice(0, urlEscapeMap['&'].length * -1);
+};
+
+export const getOauthGoogleRedirectUrl = (
+  isLoginRequest: boolean = false,
+  csrfToken: string,
+) => {
   const params = {
     redirect_uri: config.oauth.google.callbackUrl,
     scope: googleOauthScope,
     client_id: config.oauth.google.clientId,
+    state: oauthStateEncoder({
+      is_login_request: isLoginRequest,
+      csrf_token: csrfToken,
+    }),
     response_type: 'code',
     access_type: 'offline',
   };

--- a/server/src/helper/oauth.ts
+++ b/server/src/helper/oauth.ts
@@ -107,11 +107,18 @@ export const getGoogleUserInfo = async (accessToken: string) => {
   return response.data;
 };
 
-export const getOauthFacebookRedirectUrl = () => {
+export const getOauthFacebookRedirectUrl = (
+  isLoginRequest: boolean = false,
+  csrfToken: string,
+) => {
   const params = {
     redirect_uri: config.oauth.facebook.callbackUrl,
     client_id: config.oauth.facebook.clientId,
     scope: facebookOauthScope,
+    state: oauthStateEncoder({
+      is_login_request: isLoginRequest,
+      csrf_token: csrfToken,
+    }),
   };
   const result = `${facebookOauthUrl}${Object.entries(params).reduce(
     (acc, cur) => `${acc}&${cur[0]}=${cur[1]}`,

--- a/server/src/repository/login.ts
+++ b/server/src/repository/login.ts
@@ -1,5 +1,6 @@
 import { EntityRepository, Repository } from 'typeorm';
 import LoginEntity from '@/entity/login';
+import { LoginType } from '@/constants/login';
 
 export interface LoginInfo {
   id: string;
@@ -9,7 +10,7 @@ export interface LoginInfo {
 
 @EntityRepository(LoginEntity)
 class LoginRepository extends Repository<LoginEntity> {
-  async findById(id: string, type: string = 'OWN') {
+  async findById(id: string, type: LoginType = LoginType.Own) {
     const account = await this.findOne({ where: { id, type } });
     return account;
   }

--- a/server/src/repository/login.ts
+++ b/server/src/repository/login.ts
@@ -1,6 +1,5 @@
 import { EntityRepository, Repository } from 'typeorm';
-import LoginEntity from '@/entity/login';
-import { LoginType } from '@/constants/login';
+import LoginEntity, { LoginType } from '@/entity/login';
 
 export interface LoginInfo {
   id: string;

--- a/server/src/repository/login.ts
+++ b/server/src/repository/login.ts
@@ -9,8 +9,8 @@ export interface LoginInfo {
 
 @EntityRepository(LoginEntity)
 class LoginRepository extends Repository<LoginEntity> {
-  async findById(id: string) {
-    const account = await this.findOne({ where: { id } });
+  async findById(id: string, type: string = 'OWN') {
+    const account = await this.findOne({ where: { id, type } });
     return account;
   }
 

--- a/server/src/service/oauth.ts
+++ b/server/src/service/oauth.ts
@@ -1,10 +1,42 @@
 import { Service } from 'typedi';
+import { InjectRepository } from 'typeorm-typedi-extensions';
 import * as oauthHelper from '@/helper/oauth';
+import * as jwtHelper from '@/helper/jwt';
+import * as authHelper from '@/helper/auth';
 import ErrorResponse from '@/utils/errorResponse';
 import { commonError } from '@/constants/error';
+import LoginRepository from '@/repository/login';
+import { LoginType } from '@/entity/login';
 
 @Service()
 class OAuthService {
+  private loginRepository: LoginRepository;
+
+  constructor(
+    @InjectRepository(LoginRepository) loginRepository: LoginRepository,
+  ) {
+    this.loginRepository = loginRepository;
+  }
+
+  async oauthLogin(id: string, type: LoginType.Google | LoginType.Facebook) {
+    try {
+      const login = await this.loginRepository.findById(id, type);
+
+      if (!login) {
+        throw new ErrorResponse(commonError.unauthorized);
+      }
+
+      const access = jwtHelper.generateAccessToken(login);
+      const refresh = jwtHelper.generateRefreshToken(login);
+
+      await authHelper.storeRefreshToken(refresh, login.idx);
+
+      return { access, refresh };
+    } catch (e) {
+      throw new ErrorResponse(commonError.unauthorized);
+    }
+  }
+
   async getGoogleAccessToken(code: string) {
     try {
       const response = await oauthHelper.getGoogleOauthToken(code);
@@ -24,6 +56,10 @@ class OAuthService {
     }
   }
 
+  googleLogin(id: string) {
+    return this.oauthLogin(id, LoginType.Google);
+  }
+
   async getFacebookAccessToken(code: string) {
     try {
       const response = await oauthHelper.getFacebookOauthToken(code);
@@ -41,6 +77,10 @@ class OAuthService {
     } catch (e) {
       throw new ErrorResponse(commonError.unauthorized);
     }
+  }
+
+  facebookLogin(id: string) {
+    return this.oauthLogin(id, LoginType.Facebook);
   }
 }
 

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -9,7 +9,7 @@
   dependencies:
     "@babel/highlight" "^7.10.4"
 
-"@babel/code-frame@^7.12.13", "@babel/code-frame@^7.14.5":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.14.5.tgz#23b08d740e83f49c5e59945fbf1b43e80bbf4edb"
   integrity sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==
@@ -811,6 +811,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.6.1.tgz#aee62c7b966f55fc66c7b6dfa1d58db2a616da61"
   integrity sha512-Sr7BhXEAer9xyGuCN3Ek9eg9xPviCF2gfu9kTfuU2HkTVAMYSDeX40fvpmo72n5nansg3nsBjuQBrsS28r+NUw==
 
+"@types/parse-json@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
+  integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
+
 "@types/prettier@^2.1.5":
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.3.2.tgz#fc8c2825e4ed2142473b4a81064e6e081463d1b3"
@@ -1005,6 +1010,14 @@ agent-base@6:
   dependencies:
     debug "4"
 
+aggregate-error@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.1.0.tgz#92670ff50f5359bdb7a3e0d40d0ec30c5737687a"
+  integrity sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==
+  dependencies:
+    clean-stack "^2.0.0"
+    indent-string "^4.0.0"
+
 ajv@^6.10.0, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
@@ -1037,7 +1050,7 @@ ansi-colors@^4.1.1:
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
   integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
 
-ansi-escapes@^4.2.1:
+ansi-escapes@^4.2.1, ansi-escapes@^4.3.0:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
   integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
@@ -1483,7 +1496,7 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.0.0, chalk@^4.1.0:
+chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -1531,10 +1544,22 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
 
+clean-stack@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
+  integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
+
 cli-boxes@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-2.2.1.tgz#ddd5035d25094fce220e9cab40a45840a440318f"
   integrity sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==
+
+cli-cursor@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307"
+  integrity sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==
+  dependencies:
+    restore-cursor "^3.1.0"
 
 cli-highlight@^2.1.11:
   version "2.1.11"
@@ -1547,6 +1572,14 @@ cli-highlight@^2.1.11:
     parse5 "^5.1.1"
     parse5-htmlparser2-tree-adapter "^6.0.0"
     yargs "^16.0.0"
+
+cli-truncate@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-2.1.0.tgz#c39e28bf05edcde5be3b98992a22deed5a2b93c7"
+  integrity sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==
+  dependencies:
+    slice-ansi "^3.0.0"
+    string-width "^4.2.0"
 
 cliui@^7.0.2:
   version "7.0.4"
@@ -1619,6 +1652,11 @@ commander@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
+
+commander@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
+  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
 
 component-emitter@^1.3.0:
   version "1.3.0"
@@ -1716,6 +1754,17 @@ cors@^2.8.5:
   dependencies:
     object-assign "^4"
     vary "^1"
+
+cosmiconfig@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.0.tgz#ef9b44d773959cae63ddecd122de23853b60f8d3"
+  integrity sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==
+  dependencies:
+    "@types/parse-json" "^4.0.0"
+    import-fresh "^3.2.1"
+    parse-json "^5.0.0"
+    path-type "^4.0.0"
+    yaml "^1.10.0"
 
 create-require@^1.1.0:
   version "1.1.1"
@@ -1985,7 +2034,7 @@ end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-enquirer@^2.3.5:
+enquirer@^2.3.5, enquirer@^2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
   integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
@@ -2593,6 +2642,11 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
     has "^1.0.3"
     has-symbols "^1.0.1"
 
+get-own-enumerable-property-symbols@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz#b5fde77f22cbe35f390b4e089922c50bce6ef664"
+  integrity sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==
+
 get-package-type@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
@@ -2881,6 +2935,11 @@ imurmurhash@^0.1.4:
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
 
+indent-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
+  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -3047,6 +3106,11 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
+is-obj@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
+  integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
+
 is-obj@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982"
@@ -3074,6 +3138,11 @@ is-regex@^1.1.3:
   dependencies:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
+
+is-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
+  integrity sha1-/S2INUXEa6xaYz57mgnof6LLUGk=
 
 is-stream@^2.0.0:
   version "2.0.1"
@@ -3105,6 +3174,11 @@ is-typedarray@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
+
+is-unicode-supported@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
+  integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
 
 is-yarn-global@^0.3.0:
   version "0.3.0"
@@ -3649,6 +3723,11 @@ json-parse-better-errors@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
   integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
 
+json-parse-even-better-errors@^2.3.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
+  integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
+
 json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
@@ -3744,6 +3823,44 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+lines-and-columns@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
+  integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
+
+lint-staged@^11.1.2:
+  version "11.1.2"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-11.1.2.tgz#4dd78782ae43ee6ebf2969cad9af67a46b33cd90"
+  integrity sha512-6lYpNoA9wGqkL6Hew/4n1H6lRqF3qCsujVT0Oq5Z4hiSAM7S6NksPJ3gnr7A7R52xCtiZMcEUNNQ6d6X5Bvh9w==
+  dependencies:
+    chalk "^4.1.1"
+    cli-truncate "^2.1.0"
+    commander "^7.2.0"
+    cosmiconfig "^7.0.0"
+    debug "^4.3.1"
+    enquirer "^2.3.6"
+    execa "^5.0.0"
+    listr2 "^3.8.2"
+    log-symbols "^4.1.0"
+    micromatch "^4.0.4"
+    normalize-path "^3.0.0"
+    please-upgrade-node "^3.2.0"
+    string-argv "0.3.1"
+    stringify-object "^3.3.0"
+
+listr2@^3.8.2:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/listr2/-/listr2-3.11.0.tgz#9771b02407875aa78e73d6e0ff6541bbec0aaee9"
+  integrity sha512-XLJVe2JgXCyQTa3FbSv11lkKExYmEyA4jltVo8z4FX10Vt1Yj8IMekBfwim0BSOM9uj1QMTJvDQQpHyuPbB/dQ==
+  dependencies:
+    cli-truncate "^2.1.0"
+    colorette "^1.2.2"
+    log-update "^4.0.0"
+    p-map "^4.0.0"
+    rxjs "^6.6.7"
+    through "^2.3.8"
+    wrap-ansi "^7.0.0"
+
 load-json-file@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
@@ -3828,6 +3945,24 @@ lodash@4.x, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+log-symbols@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.1.0.tgz#3fbdbb95b4683ac9fc785111e792e558d4abd503"
+  integrity sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==
+  dependencies:
+    chalk "^4.1.0"
+    is-unicode-supported "^0.1.0"
+
+log-update@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-4.0.0.tgz#589ecd352471f2a1c0c570287543a64dfd20e0a1"
+  integrity sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==
+  dependencies:
+    ansi-escapes "^4.3.0"
+    cli-cursor "^3.1.0"
+    slice-ansi "^4.0.0"
+    wrap-ansi "^6.2.0"
 
 long@^4.0.0:
   version "4.0.0"
@@ -4265,7 +4400,7 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
-onetime@^5.1.2:
+onetime@^5.1.0, onetime@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
@@ -4334,6 +4469,13 @@ p-locate@^4.1.0:
   dependencies:
     p-limit "^2.2.0"
 
+p-map@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-4.0.0.tgz#bb2f95a5eda2ec168ec9274e06a747c3e2904d2b"
+  integrity sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==
+  dependencies:
+    aggregate-error "^3.0.0"
+
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
@@ -4373,6 +4515,16 @@ parse-json@^4.0.0:
   dependencies:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
+
+parse-json@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
+  integrity sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    error-ex "^1.3.1"
+    json-parse-even-better-errors "^2.3.0"
+    lines-and-columns "^1.1.6"
 
 parse5-htmlparser2-tree-adapter@^6.0.0:
   version "6.0.1"
@@ -4485,6 +4637,13 @@ pkg-up@^2.0.0:
   integrity sha1-yBmscoBZpGHKscOImivjxJoATX8=
   dependencies:
     find-up "^2.1.0"
+
+please-upgrade-node@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"
+  integrity sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==
+  dependencies:
+    semver-compare "^1.0.0"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -4790,6 +4949,14 @@ responselike@^1.0.2:
   dependencies:
     lowercase-keys "^1.0.0"
 
+restore-cursor@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-3.1.0.tgz#39f67c54b3a7a58cea5236d95cf0034239631f7e"
+  integrity sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==
+  dependencies:
+    onetime "^5.1.0"
+    signal-exit "^3.0.2"
+
 reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
@@ -4808,6 +4975,13 @@ run-parallel@^1.1.6, run-parallel@^1.1.9:
   integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
     queue-microtask "^1.2.2"
+
+rxjs@^6.6.7:
+  version "6.6.7"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
+  integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
+  dependencies:
+    tslib "^1.9.0"
 
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
@@ -4840,6 +5014,11 @@ saxes@^5.0.1:
   integrity sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==
   dependencies:
     xmlchars "^2.2.0"
+
+semver-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
+  integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
 semver-diff@^3.1.1:
   version "3.1.1"
@@ -4970,6 +5149,15 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
+slice-ansi@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-3.0.0.tgz#31ddc10930a1b7e0b67b08c96c2f49b77a789787"
+  integrity sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==
+  dependencies:
+    ansi-styles "^4.0.0"
+    astral-regex "^2.0.0"
+    is-fullwidth-code-point "^3.0.0"
+
 slice-ansi@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b"
@@ -5054,6 +5242,11 @@ streamsearch@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-0.1.2.tgz#808b9d0e56fc273d809ba57338e929919a1a9f1a"
   integrity sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=
+
+string-argv@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
+  integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
 
 string-length@^4.0.1:
   version "4.0.2"
@@ -5141,6 +5334,15 @@ string_decoder@~1.1.1:
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
+
+stringify-object@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/stringify-object/-/stringify-object-3.3.0.tgz#703065aefca19300d3ce88af4f5b3956d7556629"
+  integrity sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==
+  dependencies:
+    get-own-enumerable-property-symbols "^3.0.0"
+    is-obj "^1.0.1"
+    is-regexp "^1.0.0"
 
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
@@ -5329,6 +5531,11 @@ throat@^6.0.1:
   resolved "https://registry.yarnpkg.com/throat/-/throat-6.0.1.tgz#d514fedad95740c12c2d7fc70ea863eb51ade375"
   integrity sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==
 
+through@^2.3.8:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+  integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
+
 tmpl@1.0.x:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
@@ -5422,7 +5629,7 @@ tsconfig-paths@^3.10.1, tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.8.1:
+tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -5749,6 +5956,15 @@ word-wrap@^1.2.3, word-wrap@~1.2.3:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
+wrap-ansi@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
+  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
@@ -5838,6 +6054,11 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
+yaml@^1.10.0:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
+  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
 yargonaut@^1.1.4:
   version "1.1.4"


### PR DESCRIPTION
## :bookmark_tabs: 제목

facebook과 google oauth 서비스를 사용해서 로그인을 할 수 있도록 api를 추가했습니다.

## :paperclip: 관련 이슈

- closes #102 

## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] loginEntity에 id와 type에 대해 unique 제약 추가
- [x] login findById 메서드 수정
- [x] google & facebook login 관련 service & controller & api 추가

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 페이스북은 https가 필요하여 테스트를 하지는 못했지만 구글은 테스트했습니다. 구글과 페이스북 로직이 비슷해서 별 문제는 없을 거라 생각하지만 실제 데모 전에 배포 미리 해서 테스트 해봐야 할 것 같아요.
- lint-staged를 설치했는 데 이것은 git add 한 파일에 대해서만 eslint, prettier를 수행하는 패키지에요. 설정 파일 : .lintstagedrc.json
- /api/oauth/google or /api/oauth/facebook으로 요청을 보내면 사용자 정보를 응답하는 데 이것은 회원가입 시 사용합니다.
- /api/oauth/google/login or /api/oauth/facebook/login으로 요청을 보내면 우리 서비스에서 발급한 access 토큰을 응답하고 쿠키에 refresh 토큰을 설정합니다.

## 🕰 실제 소요 시간

> 작업을 시작하기 부터 PR을 올리기 까지 소요된 시간입니다.

- 2.3h
