### PR TITLE
Feature/#108 [FE] OAuth Callback 페이지 구현

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@babel/runtime": "^7.15.3",
     "axios": "^0.21.1",
+    "query-string": "^7.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-is": "^17.0.2",
@@ -32,6 +33,7 @@
     "@babel/preset-typescript": "^7.15.0",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.0.0",
+    "@types/query-string": "^6.3.0",
     "@types/react": "^17.0.16",
     "@types/react-dom": "^17.0.9",
     "@types/styled-components": "^5.1.12",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,6 +10,8 @@ import MyPage from './pages/MyPage';
 import ProductList from './pages/ProductList';
 import MainPage from './pages/Main';
 import CartPage from './pages/Cart';
+import GoogleCallbackPage from './pages/GoogleCallback';
+import FacebookCallbackPage from './pages/FacebookCallback';
 
 const Main = styled.main`
   position: relative;
@@ -43,6 +45,12 @@ const App = () => {
           </Route>
           <Route exact path="/cart">
             <CartPage />
+          </Route>
+          <Route exact path="/oauth/google/callback">
+            <GoogleCallbackPage />
+          </Route>
+          <Route exact path="/oauth/facebook/callback">
+            <FacebookCallbackPage />
           </Route>
         </Switch>
       </Main>

--- a/client/src/components/callback/OauthCallback.tsx
+++ b/client/src/components/callback/OauthCallback.tsx
@@ -1,0 +1,72 @@
+import { FC, useEffect } from 'react';
+import queryString from 'query-string';
+import { useLocation, useHistory } from '~/core/Router';
+import useUser from '~/lib/hooks/useUser';
+import { alert } from '~/utils/modal';
+import {
+  ApiResponse,
+  AuthResponseBody,
+  ErrorResponse,
+  OauthCallbackGetRequestQuery,
+  OauthCallbackGetResponseBody,
+} from '~/lib/api/types';
+import oauthStateDecoder from '~/utils/oauthStateDecoder';
+
+const invalidCallbackUrl = 'Invalid Oauth Callback URL';
+
+interface Props {
+  oauthLoginCallback: (
+    query: OauthCallbackGetRequestQuery,
+  ) => Promise<ApiResponse<AuthResponseBody>>;
+  oauthCallback: (
+    query: OauthCallbackGetRequestQuery,
+  ) => Promise<ApiResponse<OauthCallbackGetResponseBody>>;
+}
+
+const OauthCallback: FC<Props> = ({ oauthLoginCallback, oauthCallback }) => {
+  const [user, setUser] = useUser();
+  const location = useLocation();
+  const { push } = useHistory();
+  const parsedQuery = queryString.parse(location.search);
+  const parsedState = oauthStateDecoder(parsedQuery?.state.toString());
+
+  useEffect(() => {
+    if (!parsedQuery || !parsedState) {
+      throw new Error(invalidCallbackUrl);
+    }
+    const { code, state } = parsedQuery;
+    const requestQuery = {
+      code: code.toString(),
+      state: state.toString(),
+    };
+
+    if (parsedState.is_login_request) {
+      oauthLoginCallback(requestQuery)
+        .then(() => {
+          // @TODO use replace instead of push
+          push('/');
+        })
+        .catch((e: ErrorResponse) => {
+          alert(e.message);
+          push('/');
+        });
+      return;
+    }
+
+    oauthCallback(requestQuery)
+      .then((response) => {
+        const { id, email, picture } = response.data;
+        setUser({ ...user, id, email, profile: picture });
+        // @TODO use replace instead of push
+        push('/');
+      })
+      .catch((e: ErrorResponse) => {
+        alert(e.message);
+        push('/');
+      });
+  }, []);
+
+  return <></>;
+};
+
+export default OauthCallback;

--- a/client/src/lib/api/auth.ts
+++ b/client/src/lib/api/auth.ts
@@ -11,12 +11,14 @@ export const authUrl = {
   refresh: `${authBaseUrl}/refresh`,
 };
 
-const setAuthorizationHeader = (response: AxiosResponse<AuthResponseBody>) => {
+export const setAuthorizationHeader = (
+  response: AxiosResponse<AuthResponseBody>,
+) => {
   const { access } = response.data;
   client.defaults.headers.common.Authorization = `Bearer ${access}`;
 };
 
-const clearAuthorizationHeader = () => {
+export const clearAuthorizationHeader = () => {
   client.defaults.headers.common.Authorization = '';
 };
 

--- a/client/src/lib/api/oauth.ts
+++ b/client/src/lib/api/oauth.ts
@@ -1,0 +1,56 @@
+import { setAuthorizationHeader } from './auth';
+import request from './request';
+import {
+  AuthResponseBody,
+  OauthCallbackGetRequestQuery,
+  OauthCallbackGetResponseBody,
+} from './types';
+
+export const oauthBaseUrl = '/api/oauth';
+
+export const oauthUrl = {
+  google: {
+    google: `${oauthBaseUrl}/google`,
+    login: `${oauthBaseUrl}/google/login`,
+    callback: `${oauthBaseUrl}/google/callback`,
+  },
+  facebook: {
+    facebook: `${oauthBaseUrl}/facebook`,
+    login: `${oauthBaseUrl}/facebook/login`,
+    callback: `${oauthBaseUrl}/facebook/callback`,
+  },
+};
+
+export const googleCallback = (query: OauthCallbackGetRequestQuery) =>
+  request<OauthCallbackGetResponseBody, null, OauthCallbackGetRequestQuery>(
+    'GET',
+    oauthUrl.google.callback,
+    null,
+    query,
+  );
+
+export const googleLoginCallback = (query: OauthCallbackGetRequestQuery) =>
+  request<AuthResponseBody, null, OauthCallbackGetRequestQuery>(
+    'GET',
+    oauthUrl.google.callback,
+    null,
+    query,
+    setAuthorizationHeader,
+  );
+
+export const facebookCallback = (query: OauthCallbackGetRequestQuery) =>
+  request<OauthCallbackGetResponseBody, null, OauthCallbackGetRequestQuery>(
+    'GET',
+    oauthUrl.facebook.callback,
+    null,
+    query,
+  );
+
+export const facebookLoginCallback = (query: OauthCallbackGetRequestQuery) =>
+  request<AuthResponseBody, null, OauthCallbackGetRequestQuery>(
+    'GET',
+    oauthUrl.facebook.callback,
+    null,
+    query,
+    setAuthorizationHeader,
+  );

--- a/client/src/lib/api/types/index.ts
+++ b/client/src/lib/api/types/index.ts
@@ -1,6 +1,7 @@
 export * from './common';
 export * from './error';
 export * from './auth';
+export * from './oauth';
 export * from './users';
 export * from './products';
 export * from './categories';

--- a/client/src/lib/api/types/oauth.ts
+++ b/client/src/lib/api/types/oauth.ts
@@ -1,0 +1,10 @@
+export interface OauthCallbackGetRequestQuery {
+  code: string;
+  state: string;
+}
+
+export interface OauthCallbackGetResponseBody {
+  id: string;
+  email: string;
+  picture: string;
+}

--- a/client/src/lib/hooks/useUser.ts
+++ b/client/src/lib/hooks/useUser.ts
@@ -5,7 +5,7 @@ const useUser = () => {
   const userContext = useContext(UserContext);
 
   if (!userContext) {
-    return [null, null];
+    return [null, null] as const;
   }
 
   const { user, setUser } = userContext;

--- a/client/src/pages/FacebookCallback/index.tsx
+++ b/client/src/pages/FacebookCallback/index.tsx
@@ -1,0 +1,13 @@
+import * as oauthApi from '~/lib/api/oauth';
+import OauthCallback from '~/components/callback/OauthCallback';
+
+const FacebookCallbackPage = () => {
+  return (
+    <OauthCallback
+      oauthCallback={oauthApi.facebookCallback}
+      oauthLoginCallback={oauthApi.facebookLoginCallback}
+    />
+  );
+};
+
+export default FacebookCallbackPage;

--- a/client/src/pages/GoogleCallback/index.tsx
+++ b/client/src/pages/GoogleCallback/index.tsx
@@ -1,0 +1,13 @@
+import * as oauthApi from '~/lib/api/oauth';
+import OauthCallback from '~/components/callback/OauthCallback';
+
+const GoogleCallbackPage = () => {
+  return (
+    <OauthCallback
+      oauthCallback={oauthApi.googleCallback}
+      oauthLoginCallback={oauthApi.googleLoginCallback}
+    />
+  );
+};
+
+export default GoogleCallbackPage;

--- a/client/src/utils/oauthStateDecoder.ts
+++ b/client/src/utils/oauthStateDecoder.ts
@@ -1,0 +1,14 @@
+const oauthStateDecoder = (state: string) => {
+  if (!state) {
+    return {};
+  }
+
+  const result: Record<string, string> = {};
+  const splittedState = state.split('&').map((v) => v.split('='));
+  splittedState.forEach(([key, value]) => {
+    result[key] = value;
+  });
+  return result;
+};
+
+export default oauthStateDecoder;

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1465,6 +1465,13 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
   integrity sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
 
+"@types/query-string@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@types/query-string/-/query-string-6.3.0.tgz#b6fa172a01405abcaedac681118e78429d62ea39"
+  integrity sha512-yuIv/WRffRzL7cBW+sla4HwBZrEXRNf1MKQ5SklPEadth+BKbDxiVG8A3iISN5B3yC4EeSCzMZP8llHTcUhOzQ==
+  dependencies:
+    query-string "*"
+
 "@types/react-dom@^17.0.9":
   version "17.0.9"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.9.tgz#441a981da9d7be117042e1a6fd3dac4b30f55add"
@@ -3689,6 +3696,11 @@ fill-range@^7.0.1:
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
+
+filter-obj@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-1.1.0.tgz#9b311112bc6c6127a16e016c6c5d7f19e0805c5b"
+  integrity sha1-mzERErxsYSehbgFsbF1/GeCAXFs=
 
 finalhandler@~1.1.2:
   version "1.1.2"
@@ -6257,6 +6269,16 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
+query-string@*, query-string@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.0.1.tgz#45bd149cf586aaa582dffc7ec7a8ad97dd02f75d"
+  integrity sha512-uIw3iRvHnk9to1blJCG3BTc+Ro56CBowJXKmNNAm3RulvPBzWLRqKSiiDk+IplJhsydwtuNMHi8UGQFcCLVfkA==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    filter-obj "^1.1.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
@@ -6999,6 +7021,11 @@ spdy@^4.0.2:
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -7030,6 +7057,11 @@ static-extend@^0.1.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-length@^4.0.1:
   version "4.0.2"


### PR DESCRIPTION
## :bookmark_tabs: 제목

google & facebook callback 페이지를 추가하였습니다.

## :paperclip: 관련 이슈

- closes #108 

## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [X] Warning Message가 발생하지 않았나요?
- [X] Coding Convention을 준수했나요?
## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] oauth callback 관련 api 요청 함수 추가
- [x] google, facebook callback 페이지 추가

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- oauth 적용은 별도의 백로그에서 작업하는 게 맞다고 생각해서 여기서는 구현하지 않았습니다.
- callback 페이지 이동 시 header 가 보이게 되는 되는 데 전체 로딩 애니메이션 같은 걸 추후에 추가하면 좋을 것 같아요
- 구글에 대해서만 테스트했고 페이스북은 https 문제 때문에 하지 못했습니다.

## 🕰 실제 소요 시간

> 작업을 시작하기 부터 PR을 올리기 까지 소요된 시간입니다.

- 1.7h
