### PR TITLE
Feature/#113 [FE] 상품 상세 페이지 레이아웃 개발

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,6 +10,7 @@ import MyPage from './pages/MyPage';
 import ProductList from './pages/ProductList';
 import MainPage from './pages/Main';
 import CartPage from './pages/Cart';
+import ProductDetail from './pages/ProductDetail';
 
 const Main = styled.main`
   position: relative;
@@ -37,6 +38,9 @@ const App = () => {
           </Route>
           <Route exact path="/products">
             <ProductList />
+          </Route>
+          <Route path="/products/:id">
+            <ProductDetail />
           </Route>
           <Route exact path="/me">
             <MyPage />

--- a/client/src/assets/index.tsx
+++ b/client/src/assets/index.tsx
@@ -68,6 +68,14 @@ const SearchBoxUnderlineSVG = `${S3_PREFIX}/product/search-box-underline.svg`;
 const VerticalDividerSVG = `${S3_PREFIX}/product/vertical-divider.svg`;
 const XSVG = `${S3_PREFIX}/product/x.svg`;
 
+// Product Detail Icons (상품 상세 페이지)
+const BackArrowSVG = `${S3_PREFIX}/product-detail/back-arrow.svg`;
+const BelowArrowSVG = `${S3_PREFIX}/product-detail/below-arrow.svg`;
+const FilledHeartSVG = `${S3_PREFIX}/product-detail/filled-heart.svg`;
+const UnfilledHeartSVG = `${S3_PREFIX}/product-detail/unfilled-heart.svg`;
+const ProductPageLayoutDividerSVG = `${S3_PREFIX}/product-detail/layout-divider.svg`;
+const ProductInfoDividerSVG = `${S3_PREFIX}/product-detail/product-info-divider.svg`;
+
 export {
   LogoSVG,
   VertLineSVG,
@@ -128,4 +136,10 @@ export {
   SearchBoxUnderlineSVG,
   VerticalDividerSVG,
   XSVG,
+  BackArrowSVG,
+  BelowArrowSVG,
+  FilledHeartSVG,
+  UnfilledHeartSVG,
+  ProductPageLayoutDividerSVG,
+  ProductInfoDividerSVG,
 };

--- a/client/src/components/base/Navigation/index.style.ts
+++ b/client/src/components/base/Navigation/index.style.ts
@@ -8,14 +8,32 @@ export const NavigationWrapper = styled.nav`
 
 export const Content = styled.div`
   height: 100%;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
+  position: relative;
+  height: 100px;
   margin: 0 auto;
   width: 920px;
 `;
 
+export const UselessDoodle = styled.div`
+  position: absolute;
+  top: calc(50% - 8px);
+  left: 0;
+  height: 16px;
+`;
+
+export const Logo = styled.div`
+  position: absolute;
+  top: calc(50% - 36.5px);
+  left: calc(50% - 116px);
+  width: 203px;
+  height: 71px;
+`;
+
 export const HeaderRightSection = styled.div`
+  position: absolute;
+  top: calc(50% - 17px);
+  right: 0;
+  /* height: 34px; */
   display: flex;
   gap: 35px;
 `;

--- a/client/src/components/base/Navigation/index.style.ts
+++ b/client/src/components/base/Navigation/index.style.ts
@@ -14,26 +14,31 @@ export const Content = styled.div`
   width: 920px;
 `;
 
+const uselessDoodleHeight = '16px';
 export const UselessDoodle = styled.div`
   position: absolute;
-  top: calc(50% - 8px);
+  top: calc(50% - ${uselessDoodleHeight} / 2);
   left: 0;
-  height: 16px;
+  height: ${uselessDoodleHeight};
 `;
 
+const logoHeight = '71px';
+const logoWidth = '203px';
+const logoOffset = '10px';
 export const Logo = styled.div`
   position: absolute;
-  top: calc(50% - 36.5px);
-  left: calc(50% - 116px);
-  width: 203px;
-  height: 71px;
+  top: calc(50% - ${logoHeight} / 2);
+  left: calc(50% - ${logoWidth} / 2 - ${logoOffset});
+  width: ${logoWidth};
+  height: ${logoHeight};
 `;
 
+const headerRightSectionHeight = '34px';
 export const HeaderRightSection = styled.div`
   position: absolute;
-  top: calc(50% - 17px);
+  top: calc(50% - ${headerRightSectionHeight} / 2);
+  height: fit-content;
   right: 0;
-  /* height: 34px; */
   display: flex;
   gap: 35px;
 `;

--- a/client/src/components/base/Navigation/index.tsx
+++ b/client/src/components/base/Navigation/index.tsx
@@ -7,6 +7,8 @@ import {
   HeaderRightSection,
   CartWrapper,
   BadgeWrapper,
+  UselessDoodle,
+  Logo,
 } from './index.style';
 
 import {
@@ -25,8 +27,12 @@ const Navigation: FC = () => {
   return (
     <NavigationWrapper>
       <Content>
-        <img src={DoodleUselessSVG} alt="useless" />
-        <img src={LogoSVG} alt="logo" />
+        <UselessDoodle>
+          <img src={DoodleUselessSVG} alt="useless" />
+        </UselessDoodle>
+        <Logo>
+          <img src={LogoSVG} alt="logo" />
+        </Logo>
         <HeaderRightSection>
           <CartWrapper>
             <img src={CartSVG} alt="cart" />

--- a/client/src/pages/ProductDetail/index.style.ts
+++ b/client/src/pages/ProductDetail/index.style.ts
@@ -1,0 +1,30 @@
+import styled from 'styled-components';
+
+export const ProductDetailWrapper = styled.main`
+  display: flex;
+  justify-content: space-between;
+  margin: 0 auto;
+  padding-top: 50px;
+  width: 900px;
+  height: 100%;
+`;
+
+export const LeftSection = styled.section`
+  width: 400px;
+  background-color: lightcoral;
+`;
+
+export const RightSection = styled(LeftSection)`
+  background-color: lightblue;
+`;
+
+export const LayoutDivider = styled.div`
+  width: fit-content;
+`;
+
+export const PrevPageButton = styled.div`
+  position: absolute;
+  top: 90px;
+  left: 0;
+  width: 40px;
+`;

--- a/client/src/pages/ProductDetail/index.tsx
+++ b/client/src/pages/ProductDetail/index.tsx
@@ -9,21 +9,17 @@ import {
   PrevPageButton,
 } from './index.style';
 
-const ProductDetail: FC = () => {
-  return (
-    <>
-      <ProductDetailWrapper>
-        <PrevPageButton>
-          <img src={BackArrowSVG} alt="back" />
-        </PrevPageButton>
-        <LeftSection />
-        <LayoutDivider aria-hidden="true">
-          <img src={ProductPageLayoutDividerSVG} alt="divider" />
-        </LayoutDivider>
-        <RightSection />
-      </ProductDetailWrapper>
-    </>
-  );
-};
+const ProductDetail: FC = () => (
+  <ProductDetailWrapper>
+    <PrevPageButton>
+      <img src={BackArrowSVG} alt="back" />
+    </PrevPageButton>
+    <LeftSection />
+    <LayoutDivider aria-hidden="true">
+      <img src={ProductPageLayoutDividerSVG} alt="divider" />
+    </LayoutDivider>
+    <RightSection />
+  </ProductDetailWrapper>
+);
 
 export default ProductDetail;

--- a/client/src/pages/ProductDetail/index.tsx
+++ b/client/src/pages/ProductDetail/index.tsx
@@ -1,0 +1,29 @@
+import { FC } from 'react';
+
+import { BackArrowSVG, ProductPageLayoutDividerSVG } from '~/assets';
+import {
+  ProductDetailWrapper,
+  LeftSection,
+  RightSection,
+  LayoutDivider,
+  PrevPageButton,
+} from './index.style';
+
+const ProductDetail: FC = () => {
+  return (
+    <>
+      <ProductDetailWrapper>
+        <PrevPageButton>
+          <img src={BackArrowSVG} alt="back" />
+        </PrevPageButton>
+        <LeftSection />
+        <LayoutDivider aria-hidden="true">
+          <img src={ProductPageLayoutDividerSVG} alt="divider" />
+        </LayoutDivider>
+        <RightSection />
+      </ProductDetailWrapper>
+    </>
+  );
+};
+
+export default ProductDetail;


### PR DESCRIPTION
## :bookmark_tabs: 제목

### 상품 상세 페이지 레이아웃 개발

<img width="1358" alt="스크린샷 2021-08-22 오후 1 53 11" src="https://user-images.githubusercontent.com/19240202/130342754-9f4b24dd-104d-4c99-ae85-b938d021d50e.png">


## :paperclip: 관련 이슈

- closes #113 

## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [ ] Test Code를 작성하였나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 레이아웃 적용
- [x] 네비게이션 바 위치 조정

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 우선 러프하게 영역을 잡아놓았지만 작업하시다가 수정이 필요하시다면 자유롭게 수정하셔도 됩니다!!

## 🕰 실제 소요 시간

> 작업을 시작하기 부터 PR을 올리기 까지 소요된 시간입니다.

- 0.8시간
