### PR TITLE
Feature/#140 [FE] 상품 상세 정보에서 장바구니 & 좋아요 API 연동 처리

### DIFF
--- a/client/src/components/productDetail/ProductDetailContainer/index.style.tsx
+++ b/client/src/components/productDetail/ProductDetailContainer/index.style.tsx
@@ -1,9 +1,5 @@
 import styled from 'styled-components';
-import {
-  FilledHeartSVG,
-  ProductInfoDividerSVG,
-  UnfilledHeartSVG,
-} from '~/assets';
+import { ProductInfoDividerSVG } from '~/assets';
 
 export const ProductDetailContainerWrapper = styled.div`
   width: 300px;
@@ -49,13 +45,6 @@ export const UserInteractArea = styled.div`
   margin-top: 25px;
 `;
 
-interface LikeButtonProps {
-  isLike: boolean;
-}
-// https://github.com/styled-components/styled-components/issues/1959
-export const LikeButton = styled.img.attrs<LikeButtonProps>(({ isLike }) => ({
-  src: isLike ? FilledHeartSVG : UnfilledHeartSVG,
-  alt: 'like button',
-}))<LikeButtonProps>`
+export const LikeButtonWrapper = styled.div`
   margin-left: 30.5px;
 `;

--- a/client/src/components/productDetail/ProductDetailContainer/index.tsx
+++ b/client/src/components/productDetail/ProductDetailContainer/index.tsx
@@ -27,13 +27,13 @@ interface Props {
     isCart: boolean;
   };
   onClickAddToCart?: (e: React.MouseEvent<HTMLButtonElement>) => void;
-  onClickAddToLike?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  onClickLike?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
 const ProductDetailContainer: FC<Props> = ({
   product,
   onClickAddToCart,
-  onClickAddToLike,
+  onClickLike,
 }) => {
   // @TODO API 명세 타입 변경 시 해당 부분 변경 필요
   const {
@@ -61,7 +61,7 @@ const ProductDetailContainer: FC<Props> = ({
           장바구니에 추가
         </Button>
         <LikeButtonWrapper>
-          <ProductLikeButton isLike={isLike} onClick={onClickAddToLike} />
+          <ProductLikeButton isLike={isLike} onClick={onClickLike} />
         </LikeButtonWrapper>
       </UserInteractArea>
     </ProductDetailContainerWrapper>

--- a/client/src/components/productDetail/ProductDetailContainer/index.tsx
+++ b/client/src/components/productDetail/ProductDetailContainer/index.tsx
@@ -1,10 +1,9 @@
-/* eslint-disable @typescript-eslint/no-use-before-define */
-import { FC } from 'react';
-
+import React, { FC } from 'react';
 import Button from '~/components/common/Button';
+import ProductLikeButton from '~/components/product/ProductLikeButton';
+// import { ProductDetailGetResponseBody } from '~/lib/api/types';
 import { formatPrice } from '~/utils/fotmatPrice';
 import SubInfos from '../SubInfos';
-
 import {
   ProductDetailContainerWrapper,
   ProductName,
@@ -13,10 +12,30 @@ import {
   OriginPrice,
   MainSectionDivider,
   UserInteractArea,
-  LikeButton,
+  LikeButtonWrapper,
 } from './index.style';
 
-const ProductDetailContainer: FC = () => {
+interface Props {
+  // @TODO API 명세 타입 변경 시 해당 부분 변경 필요
+  product: {
+    name: string;
+    originPrice: number;
+    discountedPrice: number;
+    mandatoryInfo: Record<string, string>;
+    deliveryInfo: Record<string, string>;
+    isLike: boolean;
+    isCart: boolean;
+  };
+  onClickAddToCart?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  onClickAddToLike?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+const ProductDetailContainer: FC<Props> = ({
+  product,
+  onClickAddToCart,
+  onClickAddToLike,
+}) => {
+  // @TODO API 명세 타입 변경 시 해당 부분 변경 필요
   const {
     name,
     discountedPrice,
@@ -24,7 +43,7 @@ const ProductDetailContainer: FC = () => {
     mandatoryInfo,
     deliveryInfo,
     isLike,
-  } = DUMMY_PRODUCT_INFO;
+  } = product;
 
   return (
     <ProductDetailContainerWrapper>
@@ -38,33 +57,15 @@ const ProductDetailContainer: FC = () => {
       <SubInfos title="배송 안내" infos={deliveryInfo} lastSubInfo />
       <MainSectionDivider />
       <UserInteractArea>
-        <Button size="lg">장바구니에 추가</Button>
-        <LikeButton isLike={isLike} />
+        <Button size="lg" onClick={onClickAddToCart}>
+          장바구니에 추가
+        </Button>
+        <LikeButtonWrapper>
+          <ProductLikeButton isLike={isLike} onClick={onClickAddToLike} />
+        </LikeButtonWrapper>
       </UserInteractArea>
     </ProductDetailContainerWrapper>
   );
-};
-
-const DUMMY_PRODUCT_INFO = {
-  name: '요모포켓X배달이친구들 엉클배달이 포켓',
-  originPrice: 99000,
-  discountedPrice: 64000,
-  mandatoryInfo: {
-    제품명: '요모포켓X배달이친구들 독고배달이 포켓',
-    치수: '6 x 7 x 10.3cm',
-    제조국: '한국(소품, 피규어, 패키지) / 중국(케이스)',
-    사용연령: '14세 이상',
-    안전표시: '작은 부품은 질식할 위험이 있으니 절대로 입에 넣지 마세요',
-  },
-  deliveryInfo: {
-    배송사: 'CJ 대한통운',
-    배송비:
-      '2,500원 (3만원 이상 구매 시 무료배송)\n도서, 산간 일부이경느 배송비가 추가될 수 있습니다.',
-    배송기간:
-      '오후 2시 이전 결제완료시 당일 출고 (영업일 기준)\n\n단, 상품의 재고 상황, 배송량, 배송지역에 따라 배송일이 추가로 소요될 수 있는 점 양해 부탁드립니다.',
-  },
-  isLike: false,
-  isCart: false,
 };
 
 export default ProductDetailContainer;

--- a/client/src/pages/ProductDetail/index.tsx
+++ b/client/src/pages/ProductDetail/index.tsx
@@ -37,7 +37,8 @@ const dummyProductInfo = {
 };
 
 const failedToAddToCart = '장바구니에 추가하는 데 실패했습니다.';
-const successToAddToCart = '장바구니에 추가하였습니다. 장바구니 페이지로 이동하시겠습니까?';
+const successToAddToCart =
+  '장바구니에 추가하였습니다. 장바구니 페이지로 이동하시겠습니까?';
 const failedToLike = '좋아요 설정을 하는 데 실패했습니다.';
 const successToLike = '이 상품에 좋아요 설정을 합니다.';
 const successToUnLike = '이 상품에 대해 좋아요 설정을 해제합니다.';
@@ -50,36 +51,42 @@ const ProductDetail: FC = () => {
 
   if (Number.isNaN(idx) || idx <= 0) {
     history.push('/404');
-    return;
+    return <></>;
   }
 
   useEffect(() => {
-    productsApi.getProductDetail(idx)
-      .then(result => setProduct(result.data))
+    productsApi
+      .getProductDetail(idx)
+      .then((result) => setProduct(result.data))
       .catch(() => history.push('/404'));
   }, [idx]);
 
   const onClickAddToCart = useCallback(() => {
-    productsApi.postProductToCart(idx)
+    productsApi
+      .postProductToCart(idx)
       .then(() => {
-        setProduct({...product, isCart: true});
+        setProduct({ ...product, isCart: true });
         confirm(successToAddToCart, () => history.push('/cart'));
       })
-      .catch(() => alert(failedToAddToCart));
+      .catch(() => {
+        alert(failedToAddToCart);
+      });
   }, [idx, product]);
 
   const onClickLike = useCallback(() => {
     if (product?.isLike) {
-      productsApi.deleteProductFromLike(idx)
+      productsApi
+        .deleteProductFromLike(idx)
         .then(() => {
-          setProduct({...product, isLike: false});
+          setProduct({ ...product, isLike: false });
           alert(successToUnLike);
         })
         .catch(() => alert(failedToLike));
     } else {
-      productsApi.postProductToLike(idx)
+      productsApi
+        .postProductToLike(idx)
         .then(() => {
-          setProduct({...product, isLike: true});
+          setProduct({ ...product, isLike: true });
           alert(successToLike);
         })
         .catch((e: ErrorResponse) => {
@@ -103,8 +110,8 @@ const ProductDetail: FC = () => {
       </LayoutDivider>
       <RightSection>
         {/* @TODO dummyProductInfo 대신 product 사용해야 함 */}
-        <ProductDetailContainer 
-          product={dummyProductInfo} 
+        <ProductDetailContainer
+          product={dummyProductInfo}
           onClickAddToCart={onClickAddToCart}
           onClickLike={onClickLike}
         />

--- a/client/src/pages/ProductDetail/index.tsx
+++ b/client/src/pages/ProductDetail/index.tsx
@@ -13,6 +13,28 @@ import {
   PrevPageButton,
 } from './index.style';
 
+const DUMMY_PRODUCT_INFO = {
+  name: '요모포켓X배달이친구들 엉클배달이 포켓',
+  originPrice: 99000,
+  discountedPrice: 64000,
+  mandatoryInfo: {
+    제품명: '요모포켓X배달이친구들 독고배달이 포켓',
+    치수: '6 x 7 x 10.3cm',
+    제조국: '한국(소품, 피규어, 패키지) / 중국(케이스)',
+    사용연령: '14세 이상',
+    안전표시: '작은 부품은 질식할 위험이 있으니 절대로 입에 넣지 마세요',
+  },
+  deliveryInfo: {
+    배송사: 'CJ 대한통운',
+    배송비:
+      '2,500원 (3만원 이상 구매 시 무료배송)\n도서, 산간 일부이경느 배송비가 추가될 수 있습니다.',
+    배송기간:
+      '오후 2시 이전 결제완료시 당일 출고 (영업일 기준)\n\n단, 상품의 재고 상황, 배송량, 배송지역에 따라 배송일이 추가로 소요될 수 있는 점 양해 부탁드립니다.',
+  },
+  isLike: false,
+  isCart: false,
+};
+
 const ProductDetail: FC = () => {
   return (
     <ProductDetailWrapper>
@@ -24,7 +46,7 @@ const ProductDetail: FC = () => {
         <DivideLine />
       </LayoutDivider>
       <RightSection>
-        <ProductDetailContainer />
+        <ProductDetailContainer product={DUMMY_PRODUCT_INFO} />
       </RightSection>
     </ProductDetailWrapper>
   );


### PR DESCRIPTION
## :bookmark_tabs: 제목

상품 상세 정보 페이지에서 장바구니 추가 버튼, 좋아요 버튼 클릭했을 때에 대한 API 요청 처리를 했습니다.

## :paperclip: 관련 이슈

- closes #140 

## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [X] Warning Message가 발생하지 않았나요?
- [X] Coding Convention을 준수했나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 페이지 마운트 시 id 값을 useParams로 받아와 해당 상품 데이터 요청 후 상태로 저장
- [x]  '장바구니에 추가'를 눌렀을 때 장바구니 추가 API 요청을 하고 confirm 모달을 띄워야 합니다.
- [x]  띄운 모달에서 장바구니 페이지로 이동할 것인지를 물어봐야 합니다.
- [x] '하트'를 클릭했을 때 좋아요 추가/삭제 API 요청 처리를 해야 합니다.

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- API 요청 타입이 수정된 버전에 대해 반영되어 있지 않아 현재는 더미 데이터로 작성하고 있습니다. 추후 수정이 필요합니다.

## 🕰 실제 소요 시간

> 작업을 시작하기 부터 PR을 올리기 까지 소요된 시간입니다.

- 1h
