### PR TITLE
Bug/#211,212 Auth 관련 장바구니 뱃지, 페이지 이슈 해결

### DIFF
--- a/client/src/components/base/Navigation/index.tsx
+++ b/client/src/components/base/Navigation/index.tsx
@@ -43,7 +43,9 @@ const Navigation: FC = () => {
               <S.CartIcon
                 activate={pathname === urls.cart || pathname === urls.shipping}
               />
-              <S.Badge badgeContent={cartAmount.toString()} />
+              {userState.isLoggedIn && (
+                <S.Badge badgeContent={cartAmount.toString()} />
+              )}
             </S.CartWrapper>
           </Link>
           <Link to="/like">

--- a/client/src/pages/CartAndShipping/index.tsx
+++ b/client/src/pages/CartAndShipping/index.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback } from 'react';
+import { FC, useCallback, useContext, useEffect } from 'react';
 import Cart from '~/components/cart/Cart';
 import Shipping from '~/components/shipping/Shipping';
 import SubPageHeader from '~/components/subpage/SubPageHeader';
@@ -6,6 +6,7 @@ import SubPageHeaderItem from '~/components/subpage/SubPageHeaderItem';
 import SubPageWrapper from '~/components/subpage/SubPageWrapper';
 import { useHistory } from '~/core/Router';
 import urls from '~/lib/constants/urls';
+import UserContext from '~/lib/contexts/userContext';
 
 interface IProps {
   pageType?: 'cart' | 'shipping';
@@ -14,6 +15,13 @@ interface IProps {
 const CartAndShippingPage: FC<IProps> = ({ pageType = 'cart' }) => {
   const { push } = useHistory();
   const isCartPage = pageType === 'cart';
+  const { user } = useContext(UserContext);
+
+  useEffect(() => {
+    if (!user.isLoggedIn)
+      push('/', { from: '/like', error: 'accessWithoutToken' });
+    return () => {};
+  }, [user]);
 
   const goCartPage = useCallback(
     () => !isCartPage && push(urls.cart),

--- a/client/src/pages/CartAndShipping/index.tsx
+++ b/client/src/pages/CartAndShipping/index.tsx
@@ -1,10 +1,13 @@
 import { FC, useCallback, useContext, useEffect } from 'react';
+
 import Cart from '~/components/cart/Cart';
 import Shipping from '~/components/shipping/Shipping';
 import SubPageHeader from '~/components/subpage/SubPageHeader';
 import SubPageHeaderItem from '~/components/subpage/SubPageHeaderItem';
 import SubPageWrapper from '~/components/subpage/SubPageWrapper';
+
 import { useHistory } from '~/core/Router';
+
 import urls from '~/lib/constants/urls';
 import UserContext from '~/lib/contexts/userContext';
 

--- a/client/src/pages/LikeList/index.tsx
+++ b/client/src/pages/LikeList/index.tsx
@@ -12,6 +12,7 @@ import * as likesApi from '~/lib/api/likes';
 import { LikesGetResponseBody } from '~/lib/api/types/likes';
 import { ErrorResponse } from '~/lib/api/types';
 import UserContext from '~/lib/contexts/userContext';
+
 import { alert } from '~/utils/modal';
 
 import { ProductLikeItemWrapper, NoResourceWrapper } from './index.style';


### PR DESCRIPTION
## :bookmark_tabs: 제목

### 비로그인 시 장바구니 뱃지 제거

<img width="988" alt="스크린샷 2021-08-28 오후 4 28 38" src="https://user-images.githubusercontent.com/19240202/131210246-92dd859c-6847-4248-9237-b3a2f21bfef3.png">


### 장바구니에서 로그인이 안되어 있는 경우 홈으로 kick out


https://user-images.githubusercontent.com/19240202/131210250-22922419-30fe-4053-a146-a6faa21b6079.mov



## :paperclip: 관련 이슈

- closes #211
- closes #212 

## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] #211
- [x] #212 

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- X

## 🕰 실제 소요 시간

> 작업을 시작하기 부터 PR을 올리기 까지 소요된 시간입니다.

- 0.6시간
