### PR TITLE
Refactor#248 [FE] context들 lib/contexts로 이동

### DIFF
--- a/client/src/lib/contexts/fetchContext.ts
+++ b/client/src/lib/contexts/fetchContext.ts
@@ -1,0 +1,14 @@
+import { FetchModuleAction } from '~/stores/fetchModule';
+import createNamedContext from './createNamedContext';
+
+interface FetchContextState {
+  state: {
+    action: string;
+    forcedDelayTime: number;
+  };
+  dispatch: (action: FetchModuleAction) => void;
+}
+
+const FetchContext = createNamedContext<FetchContextState>('FetchContext');
+
+export default FetchContext;

--- a/client/src/lib/contexts/filterContext.ts
+++ b/client/src/lib/contexts/filterContext.ts
@@ -1,0 +1,12 @@
+import { ActionType } from '~/stores/productListModule';
+import { ProductsGetRequestQuery } from '../api/types';
+import createNamedContext from './createNamedContext';
+
+interface FilterContextState {
+  state: ProductsGetRequestQuery;
+  dispatch: (action: ActionType) => void;
+}
+
+const FilterContext = createNamedContext<FilterContextState>('FilterContext');
+
+export default FilterContext;

--- a/client/src/lib/hooks/useScrollPoint.ts
+++ b/client/src/lib/hooks/useScrollPoint.ts
@@ -1,0 +1,18 @@
+import { useCallback, useEffect, useState } from 'react';
+
+const useScrollPoint = (targetPoint: number): boolean => {
+  const [isScrollPoint, setIsScrollPoint] = useState(false);
+
+  const handleScroll = useCallback(() => {
+    setIsScrollPoint(window.pageYOffset > targetPoint);
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  return isScrollPoint;
+};
+
+export default useScrollPoint;

--- a/client/src/pages/ProductList/index.tsx
+++ b/client/src/pages/ProductList/index.tsx
@@ -1,20 +1,8 @@
-import {
-  FC,
-  createContext,
-  useEffect,
-  useState,
-  useRef,
-  useCallback,
-} from 'react';
+import { FC, useEffect, useState, useRef } from 'react';
 
 import * as productsAPI from '~/lib/api/products';
-import {
-  ErrorResponse,
-  ProductsGetRequestQuery,
-  ProductsGetResponseBody,
-} from '~/lib/api/types';
+import { ErrorResponse, ProductsGetResponseBody } from '~/lib/api/types';
 import productListModule, {
-  ActionType,
   setCategory,
   setLastPage,
   setNextPage,
@@ -35,13 +23,17 @@ import {
 import useIntersection from '~/lib/hooks/useIntersection';
 import ScrollToTop from '~/components/productList/ScrollToTop';
 import fetchModule, {
-  FetchModuleAction,
   finishFetch,
   initFetch,
   INIT_FETCH,
   START_FETCH,
 } from '~/stores/fetchModule';
 import { useLocation } from '~/core/Router';
+
+import FilterContext from '~/lib/contexts/filterContext';
+import FetchContext from '~/lib/contexts/fetchContext';
+
+import useScrollPoint from '~/lib/hooks/useScrollPoint';
 
 // Constants
 const CATEGORY_TO_IDX = {
@@ -64,34 +56,6 @@ export interface ProductData {
   originPrice: number;
   discountedPrice: number;
 }
-
-interface FilterContextState {
-  state: ProductsGetRequestQuery;
-  dispatch: (action: ActionType) => void;
-}
-
-interface FetchContextState {
-  state: {
-    action: string;
-    forcedDelayTime: number;
-  };
-  dispatch: (action: FetchModuleAction) => void;
-}
-
-// Context
-export const FilterContext = createContext<FilterContextState>(null);
-export const FetchContext = createContext<FetchContextState>(null);
-
-// Hook (only use in here)
-const useScrollPoint = (targetPoint: number): boolean => {
-  const [isScrollPoint, setIsScrollPoint] = useState(false);
-
-  const handleScroll = useCallback(() => {
-    setIsScrollPoint(window.pageYOffset > targetPoint);
-  }, []);
-  window.addEventListener('scroll', handleScroll);
-  return isScrollPoint;
-};
 
 // Component
 const ProductList: FC = () => {


### PR DESCRIPTION
## :bookmark_tabs: 제목

현재 사용중인 context들을 lib/context로 이동시켰습니다.

## :paperclip: 관련 이슈

- closes #248 

## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] productList에서만 context가 정의되어 있길래 해당 부분을 lib/contexts로 분리
- [ ] productList에서 사용되고 있는 hook 재사용성을 고려해서 lib/hooks으로 분리

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- None

## 🕰 실제 소요 시간

> 작업을 시작하기 부터 PR을 올리기 까지 소요된 시간입니다.

- 0.3h
