### PR TITLE
Feature/#253 [BE] view api 적용 및 추천상품 로직 변경

### DIFF
--- a/client/src/pages/ProductDetail/index.tsx
+++ b/client/src/pages/ProductDetail/index.tsx
@@ -83,7 +83,7 @@ const ProductDetail: FC = () => {
     if (!userState.error && !userState.isLoggedIn) return;
 
     if (userState.user) {
-      productsApi.postProductToView(idx);
+      productsApi.postProductToView(idx).catch(() => {});
     }
 
     productsApi

--- a/client/src/pages/ProductDetail/index.tsx
+++ b/client/src/pages/ProductDetail/index.tsx
@@ -81,6 +81,11 @@ const ProductDetail: FC = () => {
     }
 
     if (!userState.error && !userState.isLoggedIn) return;
+
+    if (userState.user) {
+      productsApi.postProductToView(idx);
+    }
+
     productsApi
       .getProductDetail(idx)
       .then((result) => setProduct(result.data))

--- a/server/src/api/routes/product/productController.ts
+++ b/server/src/api/routes/product/productController.ts
@@ -80,11 +80,16 @@ export const handleAddView = async (
       throw new ErrorResponse(commonError.invalidPathParams);
     }
 
-    const { idx, createdAt, updatedAt } = await productServiceInstance.addView(
+    const data = await productServiceInstance.addView(
       productIdx,
       req.currentUser.idx,
     );
-    res.json({ idx, createdAt, updatedAt });
+
+    res.json({
+      idx: data?.idx,
+      createdAt: data?.createdAt,
+      updatedAt: data?.updatedAt,
+    });
   } catch (e) {
     next(e);
   }

--- a/server/src/repository/view.ts
+++ b/server/src/repository/view.ts
@@ -1,4 +1,4 @@
-import { EntityRepository, Repository } from 'typeorm';
+import { EntityRepository, Repository, getManager } from 'typeorm';
 import ViewEntity from '@/entity/view';
 import UserEntity from '@/entity/user';
 import ProductEntity from '@/entity/product';
@@ -12,6 +12,21 @@ class ViewRepository extends Repository<ViewEntity> {
 
     const savedView = await this.save(view);
     return savedView;
+  }
+
+  async findTopViewedCategoryByUser(userIdx: number) {
+    const views = getManager().query(`
+      select c.idx, count(c.idx) as cnt
+      from view v
+      left join product p on p.idx = v.product_idx
+      left join category c on category_idx = c.idx
+      where user_idx=${userIdx}
+      group by c.idx
+      order by cnt desc
+      limit 1;
+    `);
+
+    return views;
   }
 
   async findByIdxOfProductAndUser(productIdx: number, userIdx: number) {

--- a/server/src/service/product.ts
+++ b/server/src/service/product.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-restricted-syntax */
+/* eslint-disable consistent-return */
 
 import { Service } from 'typedi';
 import { InjectRepository } from 'typeorm-typedi-extensions';
@@ -86,6 +87,7 @@ class ProductService {
         productIdx,
         userIdx,
       );
+
       if (existingView) {
         const { idx, updatedAt, createdAt } = existingView;
         return { idx, updatedAt, createdAt };
@@ -99,7 +101,9 @@ class ProductService {
       if (e?.isOperational) {
         throw e;
       }
-      throw new ErrorResponse(productViewError.unable);
+      if (e.errno !== 1062) {
+        throw new ErrorResponse(productViewError.unable);
+      }
     }
   }
 

--- a/server/src/service/product.ts
+++ b/server/src/service/product.ts
@@ -115,8 +115,24 @@ class ProductService {
         productIdx,
       );
 
+      let categoryIdx;
+
+      if (includeCategory) {
+        categoryIdx = includeCategory.category.idx;
+      }
+
+      if (loginIdx) {
+        const views = await this.viewRepository.findTopViewedCategoryByUser(
+          loginIdx,
+        );
+
+        if (views.length) {
+          categoryIdx = views[0].idx;
+        }
+      }
+
       const recommend = await this.productRepository.findTopRankByCategory(
-        includeCategory!.category.idx,
+        categoryIdx,
         product.idx,
       );
 


### PR DESCRIPTION
## :bookmark_tabs: 제목

view api 적용 및 추천상품 로직 변경

## :paperclip: 관련 이슈

- closes #253 

## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] Test Code를 작성하였나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] view api 적용
- [x] 추천상품 로직 변경

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 비로그인 시 : 해당 상품 카테고리의 top rank 4개 상품을 추천해줍니다.
- 로그인 시 : 해당 유저가 본 가장 많은 상품 카테고리의  top rank 4개 상품을 추천해줍니다.
- 로그인 시 가장 많이 본 카테고리를 찾는 과정에서 typeorm 쿼리빌더로 많은 삽질을 하였으나 방법을 찾지 못해 쿼리문을 바로 넣었습니다.


## 🕰 실제 소요 시간

> 작업을 시작하기 부터 PR을 올리기 까지 소요된 시간입니다.

- 3h+
