### PR TITLE
Bug/#257,258 상품 목록 페이지 스크롤 개선

### DIFF
--- a/client/src/components/productList/ProductItemContainer/index.style.ts
+++ b/client/src/components/productList/ProductItemContainer/index.style.ts
@@ -33,6 +33,23 @@ export const NoResourceWrapper = styled.div`
 `;
 
 export const ListFooter = styled.div`
+  position: relative;
   width: 100%;
   height: 100px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const LoadingText = styled.span`
+  font-size: 30px;
+  font-family: 'BM Hanna' !important;
+`;
+
+export const ScrollTriggerDiv = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 5px;
+  height: 5px;
 `;

--- a/client/src/components/productList/ProductItemContainer/index.style.ts
+++ b/client/src/components/productList/ProductItemContainer/index.style.ts
@@ -1,13 +1,13 @@
 import styled from 'styled-components';
 
-export const ProductItemContainerWrapper = styled.div`
+const ProductItemContainerWrapper = styled.div`
   position: relative;
   width: 100%;
   height: fit-content;
   margin-bottom: 50px;
 `;
 
-export const ItemList = styled.ul<{
+const ItemList = styled.ul<{
   isFetching: boolean;
   delayedTime: number;
 }>`
@@ -20,7 +20,7 @@ export const ItemList = styled.ul<{
   transition: opacity ${({ delayedTime }) => delayedTime}s ease-in;
 `;
 
-export const NoResourceWrapper = styled.div`
+const NoResourceWrapper = styled.div`
   z-index: -1;
   position: absolute;
   top: 0;
@@ -32,7 +32,7 @@ export const NoResourceWrapper = styled.div`
   align-items: center;
 `;
 
-export const ListFooter = styled.div`
+const ListFooter = styled.div`
   position: relative;
   width: 100%;
   height: 100px;
@@ -41,15 +41,24 @@ export const ListFooter = styled.div`
   align-items: center;
 `;
 
-export const LoadingText = styled.span`
-  font-size: 30px;
+const LoadingText = styled.span`
+  font-size: 25px;
   font-family: 'BM Hanna' !important;
 `;
 
-export const ScrollTriggerDiv = styled.div`
+const ScrollTriggerDiv = styled.div`
   position: absolute;
   top: 0;
   left: 0;
   width: 5px;
   height: 5px;
 `;
+
+export default {
+  ProductItemContainerWrapper,
+  ItemList,
+  NoResourceWrapper,
+  ListFooter,
+  LoadingText,
+  ScrollTriggerDiv,
+};

--- a/client/src/components/productList/ProductItemContainer/index.tsx
+++ b/client/src/components/productList/ProductItemContainer/index.tsx
@@ -14,14 +14,7 @@ import FilterContext from '~/lib/contexts/filterContext';
 import { ProductData } from '~/pages/ProductList';
 import { FINISH_FETCH, INIT_FETCH, START_FETCH } from '~/stores/fetchModule';
 
-import {
-  ProductItemContainerWrapper,
-  ListFooter,
-  ItemList,
-  NoResourceWrapper,
-  ScrollTriggerDiv,
-  LoadingText,
-} from './index.style';
+import S from './index.style';
 
 interface Props {
   products: ProductData[];
@@ -42,8 +35,8 @@ const ProductItemContainer: ForwardRefRenderFunction<HTMLDivElement, Props> = (
   );
 
   return (
-    <ProductItemContainerWrapper>
-      <ItemList
+    <S.ProductItemContainerWrapper>
+      <S.ItemList
         isFetching={fetchState.action === START_FETCH}
         delayedTime={fetchState.forcedDelayTime / 1000}
       >
@@ -58,20 +51,20 @@ const ProductItemContainer: ForwardRefRenderFunction<HTMLDivElement, Props> = (
               onClick={() => pushToProductDetailPage(idx)}
             />
           ))}
-        <NoResourceWrapper>
+        <S.NoResourceWrapper>
           {products.length === 0 && fetchState.action !== INIT_FETCH && (
             <NoResource content={NO_RESOURCE_CONTENT} />
           )}
-        </NoResourceWrapper>
-      </ItemList>
-      <ListFooter>
-        <ScrollTriggerDiv ref={ref} />
+        </S.NoResourceWrapper>
+      </S.ItemList>
+      <S.ListFooter>
+        <S.ScrollTriggerDiv ref={ref} />
         {fetchState.action === FINISH_FETCH && !filterState.isLastPage && (
-          <LoadingText>로딩중</LoadingText>
+          <S.LoadingText>로딩중</S.LoadingText>
         )}
-        {filterState.isLastPage && <LoadingText>끝</LoadingText>}
-      </ListFooter>
-    </ProductItemContainerWrapper>
+        {filterState.isLastPage && <S.LoadingText>끝</S.LoadingText>}
+      </S.ListFooter>
+    </S.ProductItemContainerWrapper>
   );
 };
 

--- a/client/src/components/productList/ProductItemContainer/index.tsx
+++ b/client/src/components/productList/ProductItemContainer/index.tsx
@@ -10,14 +10,17 @@ import ProductItem from '~/components/product/ProductItem';
 
 import { useHistory } from '~/core/Router';
 import FetchContext from '~/lib/contexts/fetchContext';
+import FilterContext from '~/lib/contexts/filterContext';
 import { ProductData } from '~/pages/ProductList';
-import { INIT_FETCH, START_FETCH } from '~/stores/fetchModule';
+import { FINISH_FETCH, INIT_FETCH, START_FETCH } from '~/stores/fetchModule';
 
 import {
   ProductItemContainerWrapper,
   ListFooter,
   ItemList,
   NoResourceWrapper,
+  ScrollTriggerDiv,
+  LoadingText,
 } from './index.style';
 
 interface Props {
@@ -31,6 +34,7 @@ const ProductItemContainer: ForwardRefRenderFunction<HTMLDivElement, Props> = (
 ) => {
   const NO_RESOURCE_CONTENT = '상품이 없어요 ㅜ ㅜ';
   const { state: fetchState } = useContext(FetchContext);
+  const { state: filterState } = useContext(FilterContext);
   const { push } = useHistory();
   const pushToProductDetailPage = useCallback(
     (idx: number) => push(`/products/${idx}`),
@@ -60,8 +64,13 @@ const ProductItemContainer: ForwardRefRenderFunction<HTMLDivElement, Props> = (
           )}
         </NoResourceWrapper>
       </ItemList>
-      {/* TODO: 원활한 UX를 위하여 추후에 로딩 스피너 또는 lazy loading 로직을 추가해야 합니다. */}
-      <ListFooter ref={ref} />
+      <ListFooter>
+        <ScrollTriggerDiv ref={ref} />
+        {fetchState.action === FINISH_FETCH && !filterState.isLastPage && (
+          <LoadingText>로딩중</LoadingText>
+        )}
+        {filterState.isLastPage && <LoadingText>끝</LoadingText>}
+      </ListFooter>
     </ProductItemContainerWrapper>
   );
 };

--- a/client/src/lib/contexts/filterContext.ts
+++ b/client/src/lib/contexts/filterContext.ts
@@ -1,9 +1,8 @@
-import { ActionType } from '~/stores/productListModule';
-import { ProductsGetRequestQuery } from '../api/types';
+import { ActionType, IFilter } from '~/stores/productListModule';
 import createNamedContext from './createNamedContext';
 
 interface FilterContextState {
-  state: ProductsGetRequestQuery;
+  state: IFilter;
   dispatch: (action: ActionType) => void;
 }
 

--- a/client/src/lib/hooks/useIntersection.ts
+++ b/client/src/lib/hooks/useIntersection.ts
@@ -19,10 +19,12 @@ export const useIntersection = (
   ref: MutableRefObject<HTMLElement>,
   { threshold = 1 }: IntersectionOption,
 ): IntersectionObserverEntry => {
+  const DELAY_TIME = 500;
   const [entry, setEntry] = useState<IntersectionObserverEntry>();
+
   const updateEntry = debounce(
     ([entry]: IntersectionObserverEntry[]) => setEntry(entry),
-    500,
+    DELAY_TIME,
   );
 
   useEffect(() => {

--- a/client/src/lib/hooks/useIntersection.ts
+++ b/client/src/lib/hooks/useIntersection.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-shadow */
 import { MutableRefObject, useEffect, useState } from 'react';
+import debounce from '~/utils/debounce';
 
 interface IntersectionOption extends IntersectionObserverInit {
   freezeOnceVisible?: boolean;
@@ -16,10 +17,13 @@ interface IntersectionOption extends IntersectionObserverInit {
  */
 export const useIntersection = (
   ref: MutableRefObject<HTMLElement>,
-  { threshold = 0 }: IntersectionOption,
+  { threshold = 1 }: IntersectionOption,
 ): IntersectionObserverEntry => {
   const [entry, setEntry] = useState<IntersectionObserverEntry>();
-  const updateEntry = ([entry]: IntersectionObserverEntry[]) => setEntry(entry);
+  const updateEntry = debounce(
+    ([entry]: IntersectionObserverEntry[]) => setEntry(entry),
+    500,
+  );
 
   useEffect(() => {
     const node = ref.current;

--- a/client/src/pages/ProductList/index.tsx
+++ b/client/src/pages/ProductList/index.tsx
@@ -63,7 +63,7 @@ const ProductList: FC = () => {
 
   const { filterState, dispatch: productListDispatch } = productListModule();
   const { state: fetchState, dispatch: fetchDispatch } = fetchModule();
-  const entry = useIntersection(listFooterRef, { threshold: 0.95 });
+  const entry = useIntersection(listFooterRef, {});
 
   const isScrollPoint = useScrollPoint(TARGET_POINT);
 

--- a/client/src/stores/fetchModule.ts
+++ b/client/src/stores/fetchModule.ts
@@ -23,7 +23,7 @@ export const initFetch = () => ({ type: INIT_FETCH });
 // State
 const INITIAL_FETCH_STATE = {
   action: 'INIT_FETCH',
-  forcedDelayTime: 300,
+  forcedDelayTime: 210,
 };
 
 // Reducer


### PR DESCRIPTION
## :bookmark_tabs: 제목

### 무한 스크롤 시에 빠르게 내려도 동작할 수 있도록 수정


https://user-images.githubusercontent.com/19240202/131244181-99d93f87-9bb6-45e5-965c-2db7691b0d99.mov



### 마지막 페이지일 경우 끝, 로딩중일 경우 로딩중 문구 추가


https://user-images.githubusercontent.com/19240202/131244189-1fe872c9-1be8-4fc7-b2f6-ab19146d10d6.mov



## :paperclip: 관련 이슈

- closes #257 
- closes #258 

## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] #257
- [x] #258

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- IntersectionObserver API 는 비동기로 동작하게 되는데, 빠르게 스크롤을 할 경우 API가 DOM의 변경 사항을 파악하지 못해 발생하는 오류였습니다. 이를 위해 debounce를 추가해주었습니다 :)

## 🕰 실제 소요 시간

> 작업을 시작하기 부터 PR을 올리기 까지 소요된 시간입니다.

- 2시간
