### PR TITLE
Bug/#222 구글 회원가입 / 로그인 오류 수정

### DIFF
--- a/client/src/components/callback/OauthCallback.tsx
+++ b/client/src/components/callback/OauthCallback.tsx
@@ -67,7 +67,7 @@ const OauthCallback: FC<Props> = ({
         })
         .catch((e: ErrorResponse) => {
           alert(e.message);
-          userDispatch(setError({ ...userState.user, error: e}));
+          userDispatch(setError({ ...userState.user, error: e }));
           push('/login');
         });
       return;
@@ -92,7 +92,7 @@ const OauthCallback: FC<Props> = ({
       });
   }, []);
 
-  return <EmptyContents/>;
+  return <EmptyContents />;
 };
 
 export default OauthCallback;

--- a/client/src/components/callback/OauthCallback.tsx
+++ b/client/src/components/callback/OauthCallback.tsx
@@ -1,4 +1,5 @@
 import { FC, useContext, useEffect } from 'react';
+import styled from 'styled-components';
 import queryString from 'query-string';
 import { useLocation, useHistory } from '~/core/Router';
 import { alert } from '~/utils/modal';
@@ -12,9 +13,19 @@ import {
 } from '~/lib/api/types';
 import oauthStateDecoder from '~/utils/oauthStateDecoder';
 import UserContext from '~/lib/contexts/userContext';
-import { setUserInfo } from '~/stores/userModule';
+import { setError, setLogin, setUserInfo } from '~/stores/userModule';
+import * as usersAPI from '~/lib/api/users';
 
 const invalidCallbackUrl = 'Invalid Oauth Callback URL';
+
+const EmptyContents = styled.div`
+  width: 100vw;
+  height: 100vh;
+  position: fixed;
+  top: 0;
+  left: 0;
+  background-color: #fff;
+`;
 
 interface Props {
   oauthLoginCallback: (
@@ -49,12 +60,14 @@ const OauthCallback: FC<Props> = ({
 
     if (parsedState.is_login_request === 'true') {
       oauthLoginCallback(requestQuery)
-        .then(() => {
-          // @TODO use replace instead of push
-          push('/');
+        .then(() => usersAPI.getMe())
+        .then((result) => {
+          userDispatch(setLogin({ ...userState.user, ...result.data }));
+          push('/products');
         })
         .catch((e: ErrorResponse) => {
           alert(e.message);
+          userDispatch(setError({ ...userState.user, error: e}));
           push('/login');
         });
       return;
@@ -79,7 +92,7 @@ const OauthCallback: FC<Props> = ({
       });
   }, []);
 
-  return <></>;
+  return <EmptyContents/>;
 };
 
 export default OauthCallback;

--- a/client/src/components/signup/SignUpForm/index.tsx
+++ b/client/src/components/signup/SignUpForm/index.tsx
@@ -3,7 +3,6 @@ import { useHistory } from '~/core/Router';
 import Button from '~/components/common/Button';
 import Copyright from '~/components/base/Copyright';
 import Space from '~/components/common/Space';
-import { oauthUrl } from '~/lib/api/oauth';
 import * as userAPI from '~/lib/api/users';
 import UserContext from '~/lib/contexts/userContext';
 import { alert } from '~/utils/modal';

--- a/client/src/components/signup/SignUpForm/index.tsx
+++ b/client/src/components/signup/SignUpForm/index.tsx
@@ -89,6 +89,7 @@ const SignUpForm: FC<{
         password: userAccount.pw,
         phone,
         email,
+        profile: social ? userState.user?.profile : null,
         privacyTermsAndConditions: policyCheck.privacyTerms,
         serviceTermsAndConditions: policyCheck.serviceTerms,
         type: social ?? 'OWN',
@@ -98,21 +99,8 @@ const SignUpForm: FC<{
         alert(message.successToSignUp);
       }
 
-      if (social === 'FACEBOOK') {
-        setTimeout(() => {
-          window.location.href = oauthUrl.facebook.login;
-        }, 500);
-        return;
-      }
-      if (social === 'GOOGLE') {
-        setTimeout(() => {
-          window.location.href = oauthUrl.google.login;
-        }, 500);
-        return;
-      }
-
       push('/login', {
-        id: social ? userState.user.id : userAccount.id,
+        id: social ? '' : userAccount.id,
         from: '/signup',
       });
     } catch (e) {

--- a/client/src/components/signup/SignUpPolicyCheck/index.tsx
+++ b/client/src/components/signup/SignUpPolicyCheck/index.tsx
@@ -21,13 +21,10 @@ const SignUpPolicyCheck: FC<IProps> = ({
     }
   };
 
-  const onCheckAll = useCallback(
-    () => {
-      const isAll = serviceTermsCheck && privacyTermsCheck;
-      onChangeCheckedTerms(!isAll, !isAll);
-    },
-    [serviceTermsCheck, privacyTermsCheck],
-  );
+  const onCheckAll = useCallback(() => {
+    const isAll = serviceTermsCheck && privacyTermsCheck;
+    onChangeCheckedTerms(!isAll, !isAll);
+  }, [serviceTermsCheck, privacyTermsCheck]);
   const onCheckServiceTerms = useCallback(
     () => onChangeCheckedTerms(!serviceTermsCheck, privacyTermsCheck),
     [serviceTermsCheck, privacyTermsCheck],

--- a/client/src/components/signup/SignUpPolicyCheck/index.tsx
+++ b/client/src/components/signup/SignUpPolicyCheck/index.tsx
@@ -22,7 +22,10 @@ const SignUpPolicyCheck: FC<IProps> = ({
   };
 
   const onCheckAll = useCallback(
-    () => onChangeCheckedTerms(!serviceTermsCheck, !privacyTermsCheck),
+    () => {
+      const isAll = serviceTermsCheck && privacyTermsCheck;
+      onChangeCheckedTerms(!isAll, !isAll);
+    },
     [serviceTermsCheck, privacyTermsCheck],
   );
   const onCheckServiceTerms = useCallback(

--- a/client/src/stores/userModule.ts
+++ b/client/src/stores/userModule.ts
@@ -57,10 +57,10 @@ const userReducer = (
     case SET_LOGOUT:
       return { ...INITIAL_STATE };
     case SET_ERROR:
-      return { 
-        ...UserModuleState, 
-        ...action.payload, 
-        user: null, 
+      return {
+        ...UserModuleState,
+        ...action.payload,
+        user: null,
       };
     case SET_USER_INFO: {
       return {

--- a/client/src/stores/userModule.ts
+++ b/client/src/stores/userModule.ts
@@ -57,10 +57,15 @@ const userReducer = (
     case SET_LOGOUT:
       return { ...INITIAL_STATE };
     case SET_ERROR:
-      return { ...UserModuleState, ...action.payload };
+      return { 
+        ...UserModuleState, 
+        ...action.payload, 
+        user: null, 
+      };
     case SET_USER_INFO: {
       return {
         ...UserModuleState,
+        error: null,
         user: { ...UserModuleState.user, ...action.payload },
       };
     }

--- a/server/src/api/routes/users/usersController.ts
+++ b/server/src/api/routes/users/usersController.ts
@@ -14,6 +14,7 @@ export const handleCreateUser = async (
       type,
       email,
       phone,
+      profile,
       privacyTermsAndConditions,
       serviceTermsAndConditions,
     } = req.body;
@@ -27,6 +28,7 @@ export const handleCreateUser = async (
       phone,
       privacyTermsAndConditions,
       serviceTermsAndConditions,
+      profile: typeof profile === 'string' ? profile : undefined,
     });
 
     return res.json({ idx, createdAt, updatedAt });

--- a/server/src/service/users.ts
+++ b/server/src/service/users.ts
@@ -43,6 +43,7 @@ class UsersService {
     type,
     email,
     phone,
+    profile,
     privacyTermsAndConditions,
     serviceTermsAndConditions,
   }: CreatableUserInfo) {
@@ -82,6 +83,7 @@ class UsersService {
       user.email = email;
       user.phone = phone;
       user.login = login;
+      user.profile = user.profile ?? profile;
 
       const { updatedUser } =
         await this.userRepository.transactionSaveWithLogin(user, login);


### PR DESCRIPTION
## :bookmark_tabs: 제목

### 구글 회원가입 테스트

https://user-images.githubusercontent.com/75124422/131244114-66f20b5f-08c9-4671-8e9f-480b5238c0ce.mov

### 구글 로그인 테스트

https://user-images.githubusercontent.com/75124422/131244122-1270f795-fd72-4946-8608-a41ea57741b9.mov

## :paperclip: 관련 이슈

- closes #222 

## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 전체 약관 동의 오류 수정(하나를 해체한 상태에서 전체 클릭 시 단순 반전만 되는 오류 수정)
- [x] 회원가입 시 profile url을 설정할 수 있도록 API 수정(+/api/users API 문서 업데이트)
- [x] Oauth 회원가입 성공 시 바로 로그인을 하지 않고 /login으로 이동
- [x] Oauth 로그인 이후 전역 상태 업데이트 로직 추가

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 원래 Oauth로 회원가입 할 때는 토큰을 반환해서 바로 로그인되게 하려고 했는 데 새로운 API 추가, 회원가입 시 type에 따른 추가 로직, 등 작업의 양이 효과에 비해 과하게 많아지는 감이 있어서 작업 방향을 바꿨습니다.
- 문제의 요지가 회원가입을 했는 데 다시 회원가입을 하는 것처럼 계정 선택이 나오는 게 문제라고 생각해서 단순히 로그인 페이지로 리다이렉트하도록 수정했습니다.
- Oauth로 받은 profile 이미지가 반영이 안되는 문제가 있었는 데 해당 부분은 profile url을 서버에서 받도록 API를 수정하여 해결했습니다.

## 🕰 실제 소요 시간

> 작업을 시작하기 부터 PR을 올리기 까지 소요된 시간입니다.

- 2h
