### PR TITLE
Bug/#207 유저구분 닉네임 추가

### DIFF
--- a/client/src/components/main/Minimi/index.tsx
+++ b/client/src/components/main/Minimi/index.tsx
@@ -1,4 +1,5 @@
 import { FC, memo } from 'react';
+import styled from 'styled-components';
 import Coord from './coord';
 import './cat/cat.css';
 import './chicken/chicken.css';
@@ -9,6 +10,7 @@ import './ladybug/ladybug.css';
 import './sonic/sonic.css';
 import './hedgehog/hedgehog.css';
 import { randBetween } from '~/utils/random';
+import { getHashedNickName } from '~/utils/hashedNickname';
 
 type Minimi =
   | 'cat'
@@ -30,13 +32,25 @@ const minimiMap = [
   'hedgehog',
 ];
 
+const PixelArtNickname = styled.div`
+  position: relative;
+  top: -10px;
+  font-size: 11px;
+  white-space: nowrap;
+  line-height: 14px;
+  text-align: center;
+`;
+
 const PixelArt: FC<{
   coord?: Coord;
   className: Minimi;
-}> = ({ coord, className }) => {
+  id?: string;
+}> = ({ coord, className, id }) => {
   return (
     <div style={{ ...coord }} className={className}>
-      {' '}
+      <PixelArtNickname>
+        {`${id ? getHashedNickName(id) : ' '}`}
+      </PixelArtNickname>
     </div>
   );
 };

--- a/client/src/components/main/RTCVideo/index.tsx
+++ b/client/src/components/main/RTCVideo/index.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable jsx-a11y/media-has-caption */
 import { FC, useRef, useEffect, memo } from 'react';
+import { getHashedNickName } from '~/utils/hashedNickname';
 import { MirroredVideo, Video } from './index.style';
 
 const RTCAudio: FC<{ id: string; stream: MediaStream; me?: boolean }> = ({
@@ -16,7 +17,7 @@ const RTCAudio: FC<{ id: string; stream: MediaStream; me?: boolean }> = ({
 
   return (
     <figure>
-      <figcaption>{id.slice(0, 8)}</figcaption>
+      <figcaption>{getHashedNickName(id)}</figcaption>
       {me ? (
         <MirroredVideo ref={videoRef} autoPlay muted />
       ) : (

--- a/client/src/pages/Main/index.tsx
+++ b/client/src/pages/Main/index.tsx
@@ -443,13 +443,18 @@ class Main extends Component<{ u?: string }, MainState> {
         <PixelArt className="cat" coord={{ left: '4%', top: '14%' }} />
         <PixelArt className="chicken" coord={{ left: '35%', top: '20%' }} />
         <PixelArt className="sonic" coord={{ left: '15%', top: '30%' }} />
-        <PixelArt className={minimi} coord={{ left: `${x}%`, top: `${y}%` }} />
+        <PixelArt
+          id={this.myId}
+          className={minimi}
+          coord={{ left: `${x}%`, top: `${y}%` }}
+        />
         <PixelArt className="flower" coord={{ top: '8%', left: '80%' }} />
         <PixelArt className="ladybug" coord={{ top: '70%' }} />
         <PixelArt className="hedgehog" coord={{ top: '80%', right: '40%' }} />
         {users.map((user) => (
           <PixelArt
             key={`${user.id}`}
+            id={user.id}
             className={user.minimi}
             coord={{ left: `${user.x}%`, top: `${user.y}%` }}
           />

--- a/client/src/utils/hashedNickname.ts
+++ b/client/src/utils/hashedNickname.ts
@@ -1,0 +1,58 @@
+/**
+ * @param s any string
+ * @returns hashed number
+ */
+const hashString = (s: string) => {
+  let h: number;
+  let i: number;
+  for (i = 0, h = 0; i < s.length; i += 1) {
+    // eslint-disable-next-line no-bitwise
+    h = (Math.imul(31, h) + s.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h);
+};
+
+const adjectives = [
+  '생활관축구대회태클마스터',
+  '대학원연구실커피마스터',
+  '탈모인협회장',
+  '스터디카페케찹뺏어먹는',
+  '훈련소에서탄피하나잃어버린',
+  '변기뚜껑닫고볼일보는',
+  '세탁소카사노바',
+  '편의점카사노바',
+  '동물원이유식연쇄절도범',
+  '중화반점단무지도둑',
+  '영어학원노숙자',
+  '시내버스에어컨지배자',
+  '무료급식소앞을서성이는',
+  '수능갤러리삼수생',
+];
+
+const names = [
+  '김찬호',
+  '엄준식',
+  '지로보센세',
+  '김수로',
+  '손석희',
+  '뽀로로',
+  '크롱',
+];
+
+/**
+ * hash함수의 특성상 같은 peerId는 같은 닉네임을 반환합니다.
+ * 따라서 모든사람이 같은 peerId를 같은 닉네임으로 인식하게됩니다.
+ *
+ * @param uuid peerId 를 넘겨주세요.
+ * @returns 랜덤 닉네임
+ */
+const getHashedNickName = (uuid: string) => {
+  const hash = hashString(uuid);
+
+  const adj = adjectives[hash % adjectives.length];
+  const name = names[hash % names.length];
+
+  return `${adj} ${name}`;
+};
+
+export { getHashedNickName };


### PR DESCRIPTION
## :bookmark_tabs: 제목

유저 구분 닉네임 추가

![image](https://user-images.githubusercontent.com/13645032/131245223-d89ccf70-c527-402c-837e-e30770c47eec.png)

## :paperclip: 관련 이슈

- closes #207 

## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] Test Code를 작성하였나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] uuid를 한글 닉네임으로 변환하는 util 함수 생성
- [x] uuid를 통해서 minimi와 영상통화 위에 유저닉네임 표시

## 🕰 실제 소요 시간

> 작업을 시작하기 부터 PR을 올리기 까지 소요된 시간입니다.

- 1 (시간)
