### PR TITLE
Bug/#280 화면에 다 렌더되기 전에 observing 이 먼저 발생할 경우, 다음 페이지로 재요청

### DIFF
--- a/client/src/components/productList/ProductItemContainer/index.tsx
+++ b/client/src/components/productList/ProductItemContainer/index.tsx
@@ -3,6 +3,8 @@ import {
   ForwardRefRenderFunction,
   useCallback,
   useContext,
+  useEffect,
+  useRef,
 } from 'react';
 import NoResource from '~/components/common/NoResource';
 
@@ -12,7 +14,8 @@ import { useHistory } from '~/core/Router';
 import FetchContext from '~/lib/contexts/fetchContext';
 import FilterContext from '~/lib/contexts/filterContext';
 import { ProductData } from '~/pages/ProductList';
-import { FINISH_FETCH, START_FETCH } from '~/stores/fetchModule';
+import { FINISH_FETCH, initFetch, START_FETCH } from '~/stores/fetchModule';
+import { setNextPage } from '~/stores/productFilterModule';
 
 import S from './index.style';
 
@@ -26,19 +29,40 @@ const ProductItemContainer: ForwardRefRenderFunction<HTMLDivElement, Props> = (
   ref,
 ) => {
   const NO_RESOURCE_CONTENT = '상품이 없어요 ㅜ ㅜ';
-  const { state: fetchState } = useContext(FetchContext);
-  const { state: filterState } = useContext(FilterContext);
+  const { state: fetchState, dispatch: fetchDispatch } =
+    useContext(FetchContext);
+  const { state: filterState, dispatch: productFilterDispatch } =
+    useContext(FilterContext);
   const { push } = useHistory();
   const pushToProductDetailPage = useCallback(
     (idx: number) => push(`/products/${idx}`),
     [],
   );
+  const itemListRef = useRef<HTMLUListElement>();
+
+  /**
+   * 만약 item container의 높이가 윈도우 높이보다 작은데 마지막 페이지고,
+   * fetchState.action이 FINISH_FETCH일 경우, 다음 페이지를 바로 요청합니다.
+   * 이 조건은 화면을 축소 시켰을 때 요청할 경우,
+   * intersection observer 가 observe 이벤트가 트리거되기 전 렌더가 되서 발생하는 문제입니다.
+   */
+  useEffect(() => {
+    if (
+      window.innerHeight > itemListRef.current.clientHeight &&
+      !filterState.isLastPage &&
+      fetchState.action === FINISH_FETCH
+    ) {
+      productFilterDispatch(setNextPage());
+      fetchDispatch(initFetch());
+    }
+  });
 
   return (
     <S.ProductItemContainerWrapper>
       <S.ItemList
         isFetching={fetchState.action === START_FETCH}
         delayedTime={fetchState.forcedDelayTime / 1000}
+        ref={itemListRef}
       >
         {products.length !== 0 &&
           products.map(({ idx, thumbnail, discountedPrice, title }) => (

--- a/client/src/components/productList/ProductItemContainer/index.tsx
+++ b/client/src/components/productList/ProductItemContainer/index.tsx
@@ -44,7 +44,7 @@ const ProductItemContainer: ForwardRefRenderFunction<HTMLDivElement, Props> = (
    * 만약 item container의 높이가 윈도우 높이보다 작은데 마지막 페이지고,
    * fetchState.action이 FINISH_FETCH일 경우, 다음 페이지를 바로 요청합니다.
    * 이 조건은 화면을 축소 시켰을 때 요청할 경우,
-   * intersection observer 가 observe 이벤트가 트리거되기 전 렌더가 되서 발생하는 문제입니다.
+   * 렌더가 되기 전 observing 이벤트가 발생해서 수정하게 된 조건입니다.
    */
   useEffect(() => {
     if (

--- a/client/src/pages/ProductList/index.tsx
+++ b/client/src/pages/ProductList/index.tsx
@@ -98,8 +98,13 @@ const ProductListPage: FC = () => {
   useEffect(() => {
     if (fetchState.action === INIT_FETCH) fetchProducts();
     if (fetchState.action === START_FETCH) {
-      setTimeout(() => fetchProducts(), fetchState.forcedDelayTime);
+      const timer = setTimeout(
+        () => fetchProducts(),
+        fetchState.forcedDelayTime,
+      );
+      return () => clearTimeout(timer);
     }
+    return () => {};
   }, [filterState, fetchState.action]);
 
   useEffect(() => {


### PR DESCRIPTION
## :bookmark_tabs: 제목

### 화면에 다 렌더되기 전에 observing 이 먼저 발생할 경우, 다음 페이지로 재요청




https://user-images.githubusercontent.com/19240202/131289793-34bc1d76-9cb5-4e09-8e11-de5a0c16933d.mov


## :paperclip: 관련 이슈

- closes #280 

## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] #280

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- X

## 🕰 실제 소요 시간

> 작업을 시작하기 부터 PR을 올리기 까지 소요된 시간입니다.

- 0.5시간
