### PR TITLE
Improve/#282 마우스 hover 시 카테고리 이름을 알려주는 tooltip 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ yarn p2p # 배포용 브로커 서버
 client/ 디렉토리에 아래 명령어를 실행합니다.
 
 ```sh
-yarn start:dev # 개발용 핫로딩 서버 (.env.dev 필요)
+yarn dev # 개발용 핫로딩 서버 (.env.dev 필요)
 # or
 yarn build # 배포용 빌드 (.env.prod 필요)
 ```

--- a/client/package.json
+++ b/client/package.json
@@ -8,8 +8,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "prebuild": "yarn clean",
-    "start": "env-cmd -f .env.prod webpack serve --mode production",
-    "start:dev": "env-cmd -f .env.dev webpack serve --mode development",
+    "dev": "env-cmd -f .env.dev webpack serve --mode development",
     "build": "env-cmd -f .env.prod webpack --mode production --progress",
     "lint": "yarn eslint --ext .tsx --ext .ts src",
     "lint:fix": "yarn eslint --ext .tsx --ext .ts src --fix",

--- a/client/src/components/main/IconButtons/index.tsx
+++ b/client/src/components/main/IconButtons/index.tsx
@@ -15,6 +15,7 @@ import {
   doodleAnnouncement1,
   doodleAnnouncement2,
 } from '~/assets';
+import { CATEGORY_TO_STR } from '~/lib/constants/categories';
 
 export const BUTTON_INFOS = {
   book: ['23%', '15%', BigBookSVG],
@@ -47,6 +48,24 @@ const ButtonWrapper = styled.button<{ category: string; entered?: boolean }>`
         `
       : ``};
   animation-play-state: ${({ entered }) => (entered ? 'running' : 'paused')};
+
+  .category-text {
+    display: inline-block;
+    opacity: 0;
+    position: absolute;
+    top: 0;
+    left: 50%;
+    width: 100px;
+    padding: 5px 10px;
+    transform: translateX(-50%);
+    color: #fff;
+    background-color: #000;
+    border-radius: 20px;
+    transition: 0.3s;
+  }
+  &:hover .category-text {
+    opacity: 1;
+  }
 `;
 
 export type TypeCategoryIcon =
@@ -79,6 +98,7 @@ const Button: FC<{
       type="button"
       entered={entered}
     >
+      <span className="category-text">{CATEGORY_TO_STR[category]}</span>
       <img src={BUTTON_INFOS[category][2]} alt="icon" />
     </ButtonWrapper>
   );

--- a/client/src/components/main/IconButtons/index.tsx
+++ b/client/src/components/main/IconButtons/index.tsx
@@ -55,13 +55,14 @@ const ButtonWrapper = styled.button<{ category: string; entered?: boolean }>`
     position: absolute;
     top: 0;
     left: 50%;
-    width: 100px;
-    padding: 5px 10px;
+    padding: 5px 20px;
     transform: translateX(-50%);
     color: #fff;
     background-color: #000;
     border-radius: 20px;
+    border: 1px solid #fff;
     transition: 0.3s;
+    word-break: keep-all;
   }
   &:hover .category-text {
     opacity: 1;

--- a/client/src/components/main/IconButtons/index.tsx
+++ b/client/src/components/main/IconButtons/index.tsx
@@ -53,7 +53,7 @@ const ButtonWrapper = styled.button<{ category: string; entered?: boolean }>`
     display: inline-block;
     opacity: 0;
     position: absolute;
-    top: 0;
+    bottom: 0;
     left: 50%;
     padding: 5px 20px;
     transform: translateX(-50%);

--- a/client/src/lib/constants/categories.ts
+++ b/client/src/lib/constants/categories.ts
@@ -1,4 +1,4 @@
-const CATEGORY_TO_IDX = {
+export const CATEGORY_TO_IDX = {
   book: 1,
   pencil: 2,
   house: 3,
@@ -10,4 +10,14 @@ const CATEGORY_TO_IDX = {
   colab: 9,
 };
 
-export default CATEGORY_TO_IDX;
+export const CATEGORY_TO_STR = {
+  book: '책',
+  hat: '을지로에디션',
+  house: '리빙',
+  kk: 'ㅋㅋ에디션',
+  baedal: '배달이친구들',
+  tree: '배민그린',
+  pencil: '문구',
+  colab: '콜라보레이션',
+  gift: '선물세트',
+};

--- a/client/src/pages/Main/index.tsx
+++ b/client/src/pages/Main/index.tsx
@@ -21,6 +21,7 @@ import createPeer from '~/lib/api/peer';
 import { alert } from '~/utils/modal';
 import { RouterContext } from '~/core/Router';
 import RTCVideo from '~/components/main/RTCVideo';
+import { CATEGORY_TO_STR } from '~/lib/constants/categories';
 
 interface MainState {
   users: { id: string; y: number; x: number; minimi: Minimi }[];
@@ -350,7 +351,9 @@ class Main extends Component<{ u?: string }, MainState> {
     );
     if (enteredCategory) {
       this.setState({ entered: enteredCategory }, () => {
-        alert(`스페이스 버튼을 눌러서 ${enteredCategory} 카테고리로 이동해요`);
+        alert(
+          `스페이스 버튼을 눌러서 ${CATEGORY_TO_STR[enteredCategory]} 카테고리로 이동해요`,
+        );
       });
     } else {
       this.setState({ entered: undefined });

--- a/client/src/pages/ProductList/index.tsx
+++ b/client/src/pages/ProductList/index.tsx
@@ -29,7 +29,7 @@ import {
 
 import S from './index.style';
 import { useHistory, useLocation } from '~/core/Router';
-import CATEGORY_TO_IDX from '~/lib/constants/categories';
+import { CATEGORY_TO_IDX } from '~/lib/constants/categories';
 import { alert } from '~/utils/modal';
 
 // Interface


### PR DESCRIPTION
## :bookmark_tabs: 제목

마우스 hover 시 카테고리 이름을 알려주는 tooltip 추가

<img width="960" alt="스크린샷 2021-08-30 오후 5 41 05" src="https://user-images.githubusercontent.com/75124422/131311878-e9fc8ae8-18f9-498e-94b5-7a2ad752ceb2.png">

## :paperclip: 관련 이슈

- closes #282 
## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 마우스 hover 시 카테고리 이름 tooltip 나옴
- [x] 캐릭터 가까이 갔을 때 변수명 대신 카테고리 이름 나오도록 수정 

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 크롱님 피드백 즉각 반영 :)

## 🕰 실제 소요 시간

> 작업을 시작하기 부터 PR을 올리기 까지 소요된 시간입니다.

- 20m
