### PR TITLE
[#284]test: UserInfoInput 컴포넌트 단위 테스트 케이스 추가

### DIFF
--- a/client/src/components/my/UserInfoInput/index.spec.tsx
+++ b/client/src/components/my/UserInfoInput/index.spec.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import 'jest-styled-components';
 
 import UserInfoInput from './index';
@@ -10,5 +9,90 @@ describe('<UserInfoInput />', () => {
       <UserInfoInput title="test" inputComponent={() => {}} />,
     );
     expect(container).toMatchSnapshot();
+  });
+
+  it('should be 수정 when defaultDisabled is true', () => {
+    const { getByText } = render(
+      <UserInfoInput title="test" defaultDisabled inputComponent={() => {}} />,
+    );
+
+    getByText('수정');
+  });
+
+  it('should be 수정 when defaultDisabled is false', () => {
+    const { getByText } = render(
+      <UserInfoInput
+        title="test"
+        defaultDisabled={false}
+        inputComponent={() => {}}
+      />,
+    );
+
+    getByText('완료');
+  });
+
+  it('should be 완료 after modify button is clicked', () => {
+    const { getByText } = render(
+      <UserInfoInput title="test" defaultDisabled inputComponent={() => {}} />,
+    );
+
+    fireEvent.click(getByText('수정'));
+
+    getByText('완료');
+  });
+
+  it('onSubmit should be called after complete button is clicked', () => {
+    let isSubmited = false;
+    const { getByText } = render(
+      <UserInfoInput
+        title="test"
+        onSubmit={() => {
+          isSubmited = true;
+        }}
+        defaultDisabled={false}
+        inputComponent={() => {}}
+      />,
+    );
+
+    fireEvent.click(getByText('완료'));
+
+    expect(isSubmited).toBeTruthy();
+  });
+
+  it('showWarning should be called when validator returns false', () => {
+    let isCalledShowWarning = false;
+    const { getByText } = render(
+      <UserInfoInput
+        title="test"
+        validator={() => false}
+        showWarning={() => {
+          isCalledShowWarning = true;
+        }}
+        defaultDisabled={false}
+        inputComponent={() => {}}
+      />,
+    );
+
+    fireEvent.click(getByText('완료'));
+
+    expect(isCalledShowWarning).toBeTruthy();
+  });
+
+  it('complete button should be enabled when onSubmit is called and validator returns true', () => {
+    const { getByText } = render(
+      <UserInfoInput
+        title="test"
+        value=""
+        validator={() => true}
+        onSubmit={() => {}}
+        defaultDisabled={false}
+        inputComponent={() => {}}
+      />,
+    );
+
+    const completeButton = getByText('완료');
+    fireEvent.click(completeButton);
+
+    expect(completeButton).toBeEnabled();
   });
 });


### PR DESCRIPTION
## :bookmark_tabs: 제목

UserInfoInput 컴포넌트에 대해 테스트를 해봄으로써 단위테스트를 경험해봅니다.

## :paperclip: 관련 이슈

- closes #284 

## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] Test Code를 작성하였나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] UserInfoInput 컴포넌트 단위 테스트 케이스 추가

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 해보니까 그렇게 어렵지도 않고 오히려 재밌었습니다.
- 우리팀은 UI 테스트에 겁을 먹었었는 데 오히려 버그 찾는 데 매우매우 도움이 될 거라는 느낌을 테스트 코드를 짜면서 받았습니다.

## 🕰 실제 소요 시간

> 작업을 시작하기 부터 PR을 올리기 까지 소요된 시간입니다.

- 20m
